### PR TITLE
ui: consolidate tokens, drop Flowbite, polish consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.redpen.json
 .redpen/
 .claude/settings.local.json
+.superpowers/

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,3 @@
+brew "rustup"
+brew "oven-sh/bun/bun"
+brew "go-task"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3010,7 +3010,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "red-pen-tauri"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "redpen-cli"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "redpen-core"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "serde",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,6 +1,35 @@
 version: "3"
 
 tasks:
+  dev:
+    desc: "Run Tauri in development mode"
+    cmds:
+      - bun run tauri dev
+
+  dev:up:
+    desc: "Install all dependencies (frontend + Rust)"
+    cmds:
+      - bun install
+      - cargo check --workspace
+
+  dev:install:
+    desc: "Build and install the desktop app and CLI locally"
+    cmds:
+      - bun run tauri build
+      - |
+        # Install desktop app
+        APP="/Applications/Red Pen.app"
+        if [ -d "$APP" ]; then
+          echo "Removing existing $APP"
+          rm -rf "$APP"
+        fi
+        cp -R target/release/bundle/macos/Red\ Pen.app /Applications/
+        echo "Installed Red Pen.app to /Applications"
+      - |
+        # Install CLI
+        cargo install --path crates/redpen-cli
+        echo "Installed redpen-cli to $(which redpen)"
+
   release:
     desc: "Bump version, update all manifests, commit, tag, and push. Usage: task release BUMP=patch|minor|major"
     requires:

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "red-pen",
@@ -27,8 +28,7 @@
         "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-fs": "^2.4.5",
         "@tauri-apps/plugin-shell": "^2.3.5",
-        "flowbite": "^4.0.1",
-        "flowbite-svelte": "^1.31.0",
+        "bits-ui": "^2.16.3",
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5",
@@ -42,8 +42,6 @@
     },
   },
   "packages": {
-    "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
-
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A=="],
 
     "@codemirror/lang-cpp": ["@codemirror/lang-cpp@6.0.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/cpp": "^1.0.0" } }, "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA=="],
@@ -142,6 +140,8 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
+    "@internationalized/date": ["@internationalized/date@3.12.0", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -185,12 +185,6 @@
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
-
-    "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
-
-    "@rollup/plugin-node-resolve": ["@rollup/plugin-node-resolve@15.3.1", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "@types/resolve": "1.20.2", "deepmerge": "^4.2.2", "is-module": "^1.0.0", "resolve": "^1.22.1" }, "peerDependencies": { "rollup": "^2.78.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA=="],
-
-    "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.1", "", { "os": "android", "cpu": "arm" }, "sha512-xB0b51TB7IfDEzAojXahmr+gfA00uYVInJGgNNkeQG6RPnCPGr7udsylFLTubuIUSRE6FkcI1NElyRt83PP5oQ=="],
 
@@ -248,6 +242,8 @@
 
     "@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@4.0.1", "", { "dependencies": { "debug": "^4.3.7" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^5.0.0", "svelte": "^5.0.0", "vite": "^6.0.0" } }, "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw=="],
 
+    "@swc/helpers": ["@swc/helpers@0.5.19", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.2.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.2" } }, "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.2", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.2", "@tailwindcss/oxide-darwin-arm64": "4.2.2", "@tailwindcss/oxide-darwin-x64": "4.2.2", "@tailwindcss/oxide-freebsd-x64": "4.2.2", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2", "@tailwindcss/oxide-linux-arm64-musl": "4.2.2", "@tailwindcss/oxide-linux-x64-gnu": "4.2.2", "@tailwindcss/oxide-linux-x64-musl": "4.2.2", "@tailwindcss/oxide-wasm32-wasi": "4.2.2", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2", "@tailwindcss/oxide-win32-x64-msvc": "4.2.2" } }, "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg=="],
@@ -275,8 +271,6 @@
     "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ=="],
 
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA=="],
-
-    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.2", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "postcss": "^8.5.6", "tailwindcss": "4.2.2" } }, "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
 
@@ -316,8 +310,6 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
-
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@typescript-eslint/types": ["@typescript-eslint/types@8.57.1", "", {}, "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ=="],
@@ -330,11 +322,11 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "apexcharts": ["apexcharts@5.10.4", "", {}, "sha512-gt0VUqZ2+mr25ScbUcKZgJr96jKYm4vjOcxEWCEh/E5F4dWqhyo3dBhPRvNNnkKiWxkMd2cBwj3ZYH3rK39fkA=="],
-
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "bits-ui": ["bits-ui@2.16.3", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.35.1", "svelte-toolbelt": "^0.10.6", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-5hJ5dEhf5yPzkRFcxzgQHScGodeo0gK0MUUXrdLlRHWaBOBGZiacWLG96j/wwFatKwZvouw7q+sn14i0fx3RIg=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
@@ -360,13 +352,13 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
-
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -394,8 +386,6 @@
 
     "esrap": ["esrap@2.2.4", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15", "@typescript-eslint/types": "^8.2.0" } }, "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
-
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
@@ -413,12 +403,6 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
-
-    "flowbite": ["flowbite@4.0.1", "", { "dependencies": { "@popperjs/core": "^2.9.3", "flowbite-datepicker": "^2.0.0", "mini-svg-data-uri": "^1.4.3", "postcss": "^8.5.1", "tailwindcss": "^4.1.12" } }, "sha512-UwUjvnqrQTiFm3uMJ0WWnzKXKoDyNyfyEzoNnxmZo6KyDzCedjqZw1UW0Oqdn+E0iYVdPu0fizydJN6e4pP9Rw=="],
-
-    "flowbite-datepicker": ["flowbite-datepicker@2.0.0", "", { "dependencies": { "@rollup/plugin-node-resolve": "^15.2.3", "@tailwindcss/postcss": "^4.1.17" } }, "sha512-m81hl0Bimq45MUg4maJLOnXrX+C9lZ0AkjMb9uotuVUSr729k/YiymWDfVAm63AYDH7g7y3rI3ke3XaBzWWqLw=="],
-
-    "flowbite-svelte": ["flowbite-svelte@1.31.0", "", { "dependencies": { "@floating-ui/dom": "^1.7.4", "@floating-ui/utils": "^0.2.10", "apexcharts": "^5.3.6", "clsx": "^2.1.1", "date-fns": "^4.1.0", "esm-env": "^1.2.2", "flowbite": "^3.1.2", "tailwind-merge": "^3.4.0", "tailwind-variants": "^3.2.2" }, "peerDependencies": { "svelte": "^5.40.0", "tailwindcss": "^4.1.4" } }, "sha512-A7Ts/R5GsL8DbgRf+8+1wdrIOOK0nq4ggEkv4RuY0oGuzH1PLBAH+bvC1L8AgQ5li9mj3o8eE9tHW7Md8yjPsw=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -448,13 +432,11 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
-
-    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
-
-    "is-module": ["is-module@1.0.0", "", {}, "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
@@ -498,6 +480,8 @@
 
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -509,8 +493,6 @@
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "mini-svg-data-uri": ["mini-svg-data-uri@1.4.4", "", { "bin": { "mini-svg-data-uri": "cli.js" } }, "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -529,8 +511,6 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
-
-    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
@@ -552,11 +532,11 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
-    "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
-
     "rollup": ["rollup@4.59.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.1", "@rollup/rollup-android-arm64": "4.59.1", "@rollup/rollup-darwin-arm64": "4.59.1", "@rollup/rollup-darwin-x64": "4.59.1", "@rollup/rollup-freebsd-arm64": "4.59.1", "@rollup/rollup-freebsd-x64": "4.59.1", "@rollup/rollup-linux-arm-gnueabihf": "4.59.1", "@rollup/rollup-linux-arm-musleabihf": "4.59.1", "@rollup/rollup-linux-arm64-gnu": "4.59.1", "@rollup/rollup-linux-arm64-musl": "4.59.1", "@rollup/rollup-linux-loong64-gnu": "4.59.1", "@rollup/rollup-linux-loong64-musl": "4.59.1", "@rollup/rollup-linux-ppc64-gnu": "4.59.1", "@rollup/rollup-linux-ppc64-musl": "4.59.1", "@rollup/rollup-linux-riscv64-gnu": "4.59.1", "@rollup/rollup-linux-riscv64-musl": "4.59.1", "@rollup/rollup-linux-s390x-gnu": "4.59.1", "@rollup/rollup-linux-x64-gnu": "4.59.1", "@rollup/rollup-linux-x64-musl": "4.59.1", "@rollup/rollup-openbsd-x64": "4.59.1", "@rollup/rollup-openharmony-arm64": "4.59.1", "@rollup/rollup-win32-arm64-msvc": "4.59.1", "@rollup/rollup-win32-ia32-msvc": "4.59.1", "@rollup/rollup-win32-x64-gnu": "4.59.1", "@rollup/rollup-win32-x64-msvc": "4.59.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -584,13 +564,13 @@
 
     "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
-    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "svelte": ["svelte@5.54.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.4", "esm-env": "^1.2.1", "esrap": "^2.2.2", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-ow8tncN097Ty8U1H+C3bM1xNlsCbnO2UZeN0lWBnv8f3jKho7QTTQ2LWbMXrPQDodLjH91n4kpNnLolyRhVE6A=="],
 
-    "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
+    "svelte-toolbelt": ["svelte-toolbelt@0.10.6", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.35.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ=="],
 
-    "tailwind-variants": ["tailwind-variants@3.2.2", "", { "peerDependencies": { "tailwind-merge": ">=3.0.0", "tailwindcss": "*" }, "optionalPeers": ["tailwind-merge"] }, "sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg=="],
+    "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
     "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
 
@@ -599,6 +579,8 @@
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -635,11 +617,5 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "flowbite-svelte/flowbite": ["flowbite@3.1.2", "", { "dependencies": { "@popperjs/core": "^2.9.3", "flowbite-datepicker": "^1.3.1", "mini-svg-data-uri": "^1.4.3", "postcss": "^8.5.1" } }, "sha512-MkwSgbbybCYgMC+go6Da5idEKUFfMqc/AmSjm/2ZbdmvoKf5frLPq/eIhXc9P+rC8t9boZtUXzHDgt5whZ6A/Q=="],
-
-    "flowbite-svelte/flowbite/flowbite-datepicker": ["flowbite-datepicker@1.3.2", "", { "dependencies": { "@rollup/plugin-node-resolve": "^15.2.3", "flowbite": "^2.0.0" } }, "sha512-6Nfm0MCVX3mpaR7YSCjmEO2GO8CDt6CX8ZpQnGdeu03WUCWtEPQ/uy0PUiNtIJjJZWnX0Cm3H55MOhbD1g+E/g=="],
-
-    "flowbite-svelte/flowbite/flowbite-datepicker/flowbite": ["flowbite@2.5.2", "", { "dependencies": { "@popperjs/core": "^2.9.3", "flowbite-datepicker": "^1.3.0", "mini-svg-data-uri": "^1.4.3" } }, "sha512-kwFD3n8/YW4EG8GlY3Od9IoKND97kitO+/ejISHSqpn3vw2i5K/+ZI8Jm2V+KC4fGdnfi0XZ+TzYqQb4Q1LshA=="],
   }
 }

--- a/crates/redpen-cli/Cargo.toml
+++ b/crates/redpen-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redpen-cli"
-version = "0.1.4"
+version = "0.1.3"
 edition = "2021"
 
 [[bin]]

--- a/crates/redpen-core/Cargo.toml
+++ b/crates/redpen-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redpen-core"
-version = "0.1.4"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]

--- a/docs/superpowers/specs/2026-03-22-ui-cleanup-design.md
+++ b/docs/superpowers/specs/2026-03-22-ui-cleanup-design.md
@@ -1,0 +1,263 @@
+# UI Consistency Cleanup — Design Spec
+
+## Goal
+
+Full-pass UI cleanup: consolidate the styling system for future theme support, raise visual consistency across all components, replace Flowbite with Bits UI + lightweight custom atoms.
+
+## 1. Token Architecture
+
+### Problem
+
+Two parallel token systems exist — legacy `:root` CSS variables (`--bg-panel`, `--accent`, etc.) and Tailwind `@theme` tokens (`graphite-*`, `coral-*`, `surface-*`). Components mix both, making theming impossible and maintenance confusing.
+
+### Solution
+
+Single semantic CSS variable layer in `:root`, consumed by Tailwind `@theme`. To add a theme, swap the `:root` values — Tailwind classes follow automatically.
+
+### Semantic Variables
+
+**Surfaces:**
+| Variable | Value (dark) | Usage |
+|----------|-------------|-------|
+| `--surface-base` | `#0E0F11` | App background |
+| `--surface-panel` | `#131417` | Side panels |
+| `--surface-editor` | `#1A1C21` | Editor area |
+| `--surface-raised` | `#22252B` | Cards, secondary buttons |
+| `--surface-highlight` | `#2A2D35` | Hover states |
+| `--surface-selection` | `#2A1E1E` | Selected items |
+
+**Text:**
+| Variable | Value (dark) | Usage |
+|----------|-------------|-------|
+| `--text-primary` | `#F0F1F3` | Main content |
+| `--text-secondary` | `#B3B7BF` | Labels, descriptions |
+| `--text-muted` | `#6B7280` | Placeholders, disabled |
+
+**Borders:**
+| Variable | Value (dark) | Usage |
+|----------|-------------|-------|
+| `--border-default` | `#2B2E36` | Dividers |
+| `--border-subtle` | `rgba(255,255,255,0.03)` | Faint inset borders |
+| `--border-emphasis` | `#3B3F4A` | Stronger dividers |
+
+**Accent:**
+| Variable | Value (dark) | Usage |
+|----------|-------------|-------|
+| `--accent` | `#F47A63` | Primary action color |
+| `--accent-hover` | `#FF9E87` | Hover state |
+| `--accent-subtle` | `rgba(244,122,99,0.12)` | Tinted backgrounds |
+| `--accent-annotation-border` | `rgba(244,122,99,0.45)` | CodeMirror annotation underline |
+
+**Status:**
+| Variable | Value | Usage |
+|----------|-------|-------|
+| `--color-success` | `#74B97A` | Success states |
+| `--color-warning` | `#E3B341` | Warnings |
+| `--color-danger` | `#D96B5F` | Errors, destructive actions |
+| `--accent-purple` | `#B07ACC` | Git renamed |
+| `--accent-teal` | `#6FA39B` | Git untracked |
+| `--accent-blue` | `#5B9BD5` | Informational |
+
+**Elevation:**
+| Variable | Value | Usage |
+|----------|-------|-------|
+| `--shadow-xs` | `0 1px 2px rgba(0,0,0,0.2)` | Subtle depth |
+| `--shadow-card` | `0 1px 2px rgba(0,0,0,0.3), 0 2px 6px rgba(0,0,0,0.15)` | Cards |
+| `--shadow-card-hover` | `0 2px 4px rgba(0,0,0,0.35), 0 4px 12px rgba(0,0,0,0.2)` | Card hover |
+| `--shadow-panel` | `0 1px 3px rgba(0,0,0,0.4), 0 4px 12px rgba(0,0,0,0.25)` | Side panels |
+| `--shadow-popover` | `0 4px 16px rgba(0,0,0,0.5), 0 8px 32px rgba(0,0,0,0.3)` | Dialogs, menus |
+| `--shadow-inset` | `inset 0 1px 2px rgba(0,0,0,0.25)` | Input fields |
+| `--gradient-panel` | `linear-gradient(180deg, rgba(255,255,255,0.02) 0%, transparent 100%)` | Panel sheen |
+| `--gradient-toolbar` | `linear-gradient(180deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0.01) 100%)` | Toolbar sheen |
+
+### Tailwind `@theme` Integration
+
+The `@theme` block maps to semantic vars:
+
+```css
+@theme {
+  --color-surface-base: var(--surface-base);
+  --color-surface-panel: var(--surface-panel);
+  --color-surface-editor: var(--surface-editor);
+  --color-surface-raised: var(--surface-raised);
+  --color-surface-highlight: var(--surface-highlight);
+  --color-surface-selection: var(--surface-selection);
+  --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-hover);
+  --color-accent-subtle: var(--accent-subtle);
+  /* ...etc */
+}
+```
+
+Components use Tailwind classes like `bg-surface-panel`, `text-accent`, `border-default`.
+
+### What Gets Removed
+
+- All legacy `--bg-*` variables
+- All `--font-ui`, `--font-size-*` variables
+- The `graphite-*` and `coral-*` color scales from `@theme` (replaced by semantic tokens)
+- The `primary-*` Flowbite mappings
+- All `--color-surface-*` duplicates currently in `@theme` (they move to `:root`)
+
+## 2. Typography Scale
+
+### Problem
+
+5+ arbitrary pixel sizes scattered across components: `text-[10px]`, `text-[11px]`, `text-[12px]`, `text-[13px]`, `text-[14px]`.
+
+### Solution
+
+4 semantic steps defined as CSS variables and Tailwind utilities:
+
+| Token | Size | Usage |
+|-------|------|-------|
+| `--text-xs` / `text-xs` | 11px | Badges, counters, status indicators |
+| `--text-sm` / `text-sm` | 12px | Labels, tree items, secondary UI |
+| `--text-base` / `text-base` | 14px | Body text, annotation content, inputs |
+| `--text-lg` / `text-lg` | 16px | Dialog titles, section headings |
+
+### Migration
+
+- `text-[10px]` → `text-xs`
+- `text-[11px]` → `text-xs`
+- `text-[12px]` → `text-sm`
+- `text-[13px]` → `text-base` (annotation body is content-level text)
+- `text-[14px]` / `text-sm` (Tailwind default) → `text-base`
+
+## 3. Component Strategy
+
+### Drop Flowbite
+
+Flowbite is used for 3 components (`Button`, `ButtonGroup`, `Kbd`), all with `!important` overrides. Remove the dependency entirely.
+
+### Adopt Bits UI
+
+Add `bits-ui` (^1.x) as a dependency. Bits UI provides headless, accessible, Svelte 5-native primitives. Adopt for:
+
+| Bits UI Primitive | Replaces | Used In |
+|-------------------|----------|---------|
+| `Dialog` | Hand-rolled backdrop + focus trap | SettingsDialog, AnnotationPopover |
+| `Context Menu` | Hand-rolled context menu | FileTree |
+| `Tooltip` | CSS `.icon-tooltip` | FileTree icon buttons |
+| `Toggle Group` | Flowbite `ButtonGroup` | FilterBar |
+
+### Custom Atoms
+
+New `src/components/ui/` directory for lightweight shared components:
+
+**`Button.svelte`** — Variants: primary, secondary, ghost, danger. Sizes: sm, md.
+
+| Variant | Styles |
+|---------|--------|
+| primary | `bg-accent text-surface-base font-semibold`, hover: `bg-accent-hover` |
+| secondary | `bg-surface-raised text-secondary border border-subtle`, hover: `bg-surface-highlight` |
+| ghost | `transparent text-secondary`, hover: `bg-surface-highlight` |
+| danger | `text-danger`, hover: `bg-danger/10` |
+
+| Size | Padding |
+|------|---------|
+| sm | `px-2.5 py-1 text-xs` |
+| md | `px-3 py-1.5 text-sm` |
+
+**`Kbd.svelte`** — Keyboard shortcut display. Styled with token colors, no Flowbite dependency.
+
+**`IconButton.svelte`** — Replaces the `.icon-btn` pattern in FileTree. Wraps Bits UI Tooltip for hover labels.
+
+## 4. Consistency Fixes
+
+### Spacing
+
+Standardize padding patterns across all components:
+
+| Context | Padding |
+|---------|---------|
+| Panel header | `px-3 py-2` |
+| Panel content area | `px-2 py-1.5` |
+| Card padding | `px-3 py-2.5` |
+| Input padding | `px-2.5 py-1.5` |
+| Dialog padding | `p-5` |
+
+### Focus & Selection
+
+Unified across all interactive elements:
+
+| State | Style |
+|-------|-------|
+| Focus ring | `ring-1 ring-accent/30` |
+| Selection background | `bg-surface-selection` |
+| Active indicator | `border-l-accent` (3px left border on cards/tree items) |
+
+### Inline Hardcoded Values
+
+Replace ~30 inline `rgba()` values in `style=` attributes with semantic tokens:
+
+- `rgba(255,255,255,0.03)` → `var(--border-subtle)`
+- `rgba(0,0,0,0.1)` → `var(--shadow-xs)`
+- `box-shadow: inset -1px 0 0 rgba(...)` → `var(--border-subtle)` as border
+- `box-shadow: 0 1px 4px rgba(...)` → `var(--shadow-xs)`
+
+Where `style=` attributes remain necessary (dynamic widths, positions), use token references instead of raw values.
+
+### Button Normalization
+
+Currently primary buttons inconsistently use `bg-coral-400`, `bg-coral-500`, `bg-coral-400 text-graphite-950`, `bg-coral-500 text-white`. All primary buttons will use the `Button` atom with `variant="primary"`.
+
+### Git Status Colors
+
+Move from hardcoded Tailwind classes in `FileTreeItem.svelte` to semantic tokens:
+
+```
+M (modified)  → --color-warning (text-warning)
+A (added)     → --color-success (text-success)
+? (untracked) → --accent-teal (text-accent-teal)
+D (deleted)   → --color-danger (text-danger)
+R (renamed)   → --accent-purple (text-accent-purple)
+```
+
+## 5. CodeMirror Theme Alignment
+
+Update `src/lib/codemirror/theme.ts` to reference the new semantic variables:
+
+| Current | New |
+|---------|-----|
+| `var(--bg-editor)` | `var(--surface-editor)` |
+| `var(--accent)` | `var(--accent)` (unchanged) |
+| `var(--border-color)` | `var(--border-default)` |
+| `var(--text-muted)` | `var(--text-muted)` (unchanged) |
+| `var(--text-secondary)` | `var(--text-secondary)` (unchanged) |
+| `var(--bg-selection)` | `var(--surface-selection)` |
+| `rgba(34, 37, 43, 0.5)` | `var(--surface-highlight)` with opacity |
+| `rgba(244, 122, 99, 0.10)` | `var(--accent-subtle)` |
+| `rgba(244, 122, 99, 0.45)` | `var(--accent-annotation-border)` — new token, keeps rgba for CodeMirror JS compat |
+
+## 6. File Structure
+
+```
+src/
+  components/
+    ui/                       ← new shared atoms
+      Button.svelte
+      Kbd.svelte
+      IconButton.svelte
+    Editor.svelte             ← unchanged
+    FileTree.svelte           ← Bits UI ContextMenu + Tooltip, use IconButton
+    FileTreeItem.svelte       ← token updates, semantic git status colors
+    AnnotationSidebar.svelte  ← token updates, use Button atom
+    AnnotationCard.svelte     ← token updates, unified selection style
+    AnnotationPopover.svelte  ← Bits UI Dialog, use Button/Kbd atoms
+    SettingsDialog.svelte     ← Bits UI Dialog, use Button atom
+    FilterBar.svelte          ← Bits UI ToggleGroup replaces Flowbite ButtonGroup
+    Toolbar.svelte            ← use IconButton atom
+    ResizeHandle.svelte       ← token updates only
+  app.css                     ← rebuilt: semantic :root vars + @theme mapping
+  lib/
+    codemirror/
+      theme.ts                ← updated to use semantic vars
+```
+
+## Out of Scope
+
+- Light theme implementation (tokens enable it; building it is a separate effort)
+- Command bar / command palette (Bits UI Command primitive is available for future work)
+- New features or functionality changes
+- Rust/backend changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "red-pen",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -33,8 +33,7 @@
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-fs": "^2.4.5",
     "@tauri-apps/plugin-shell": "^2.3.5",
-    "flowbite": "^4.0.1",
-    "flowbite-svelte": "^1.31.0"
+    "bits-ui": "^2.16.3"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red-pen-tauri"
-version = "0.1.4"
+version = "0.1.3"
 edition = "2021"
 
 [build-dependencies]

--- a/src-tauri/src/commands/annotations.rs
+++ b/src-tauri/src/commands/annotations.rs
@@ -56,6 +56,75 @@ pub fn get_annotations(file_path: String) -> Result<SidecarFile, String> {
     load_sidecar_for_file(&project_root, source_path)
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileAnnotations {
+    pub file_path: String,
+    pub file_name: String,
+    pub annotations: Vec<Annotation>,
+}
+
+#[tauri::command]
+pub fn get_all_annotations(root_folder: String) -> Result<Vec<FileAnnotations>, String> {
+    let root = Path::new(&root_folder);
+    let project_root = resolve_project_root(root);
+    let comments_dir = project_root.join(".redpen").join("comments");
+
+    if !comments_dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut results = Vec::new();
+    collect_sidecar_files(&comments_dir, &project_root, &mut results)?;
+    results.sort_by(|a, b| a.file_path.cmp(&b.file_path));
+    Ok(results)
+}
+
+fn collect_sidecar_files(
+    dir: &Path,
+    project_root: &Path,
+    results: &mut Vec<FileAnnotations>,
+) -> Result<(), String> {
+    let entries = fs::read_dir(dir).map_err(|e| e.to_string())?;
+    for entry in entries {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_sidecar_files(&path, project_root, results)?;
+        } else if path.extension().map_or(false, |e| e == "json") {
+            if let Ok(sidecar) = SidecarFile::load(&path) {
+                if !sidecar.annotations.is_empty() {
+                    // Reconstruct source path from sidecar path
+                    let relative = path
+                        .strip_prefix(project_root.join(".redpen").join("comments"))
+                        .unwrap_or(&path);
+                    // The sidecar file is named "filename.ext.json", so strip the trailing .json
+                    let source_relative = relative.with_file_name(
+                        relative
+                            .file_name()
+                            .unwrap()
+                            .to_string_lossy()
+                            .trim_end_matches(".json"),
+                    );
+                    let source_path = project_root.join(&source_relative);
+                    let file_name = source_relative
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .to_string();
+
+                    results.push(FileAnnotations {
+                        file_path: source_path.to_string_lossy().to_string(),
+                        file_name,
+                        annotations: sidecar.annotations,
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub fn create_annotation(
     request: CreateAnnotationRequest,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod state;
 use state::AppState;
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri::{Emitter, Manager};
+use tauri::menu::{MenuBuilder, SubmenuBuilder, MenuItemBuilder, PredefinedMenuItem};
 
 #[tauri::command]
 fn get_pending_deep_links(state: tauri::State<AppState>) -> Vec<String> {
@@ -23,6 +24,7 @@ pub fn run() {
             commands::files::read_directory,
             commands::files::read_file,
             commands::annotations::get_annotations,
+            commands::annotations::get_all_annotations,
             commands::annotations::create_annotation,
             commands::annotations::update_annotation,
             commands::annotations::delete_annotation,
@@ -35,6 +37,61 @@ pub fn run() {
             get_pending_deep_links,
         ])
         .setup(|app| {
+            // Build native menu bar
+            let settings_item = MenuItemBuilder::with_id("settings", "Settings...")
+                .accelerator("Cmd+,")
+                .build(app)?;
+
+            let app_submenu = SubmenuBuilder::new(app, "Red Pen")
+                .item(&PredefinedMenuItem::about(app, Some("About Red Pen"), None)?)
+                .separator()
+                .item(&settings_item)
+                .separator()
+                .services()
+                .separator()
+                .hide()
+                .hide_others()
+                .show_all()
+                .separator()
+                .quit()
+                .build()?;
+
+            let edit_submenu = SubmenuBuilder::new(app, "Edit")
+                .undo()
+                .redo()
+                .separator()
+                .cut()
+                .copy()
+                .paste()
+                .select_all()
+                .build()?;
+
+            let view_submenu = SubmenuBuilder::new(app, "View")
+                .fullscreen()
+                .build()?;
+
+            let window_submenu = SubmenuBuilder::new(app, "Window")
+                .minimize()
+                .close_window()
+                .build()?;
+
+            let menu = MenuBuilder::new(app)
+                .item(&app_submenu)
+                .item(&edit_submenu)
+                .item(&view_submenu)
+                .item(&window_submenu)
+                .build()?;
+
+            app.set_menu(menu)?;
+
+            // Handle menu events
+            let handle_menu = app.handle().clone();
+            app.on_menu_event(move |_app, event| {
+                if event.id().0 == "settings" {
+                    let _ = handle_menu.emit("open-settings", ());
+                }
+            });
+
             // Handle deep links received while app is running (warm start)
             let handle = app.handle().clone();
             app.deep_link().on_open_url(move |event| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasVilela/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Red Pen",
-  "version": "0.1.4",
+  "version": "0.1.3",
   "identifier": "com.redpen.app",
   "build": {
     "frontendDist": "../dist",
@@ -18,8 +18,8 @@
         "height": 800,
         "minWidth": 800,
         "minHeight": 500,
-        "titleBarStyle": "Overlay",
-        "hiddenTitle": true,
+        "titleBarStyle": "Visible",
+        "hiddenTitle": false,
         "decorations": true,
         "transparent": false
       }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import Toolbar from "./components/Toolbar.svelte";
   import FileTree from "./components/FileTree.svelte";
   import Editor from "./components/Editor.svelte";
   import AnnotationSidebar from "./components/AnnotationSidebar.svelte";
@@ -66,8 +65,14 @@
   // Deep link cleanup functions
   let unlistenDeepLink: (() => void) | undefined;
   let unlistenDeepLinkEvent: (() => void) | undefined;
+  let unlistenSettings: (() => void) | undefined;
 
   onMount(async () => {
+    // Listen for settings menu event from native menu bar
+    unlistenSettings = await listen("open-settings", () => {
+      showSettings = true;
+    });
+
     // Drag-and-drop handling
     const appWindow = getCurrentWebviewWindow();
     await appWindow.onDragDropEvent(async (event) => {
@@ -132,6 +137,7 @@
   onDestroy(() => {
     unlistenDeepLink?.();
     unlistenDeepLinkEvent?.();
+    unlistenSettings?.();
     stopWatcher?.();
   });
 
@@ -175,10 +181,8 @@
 <svelte:window onkeydown={handleKeydown} oncontextmenu={(e) => e.preventDefault()} />
 
 <div class="app-root">
-  <Toolbar onSettingsClick={() => (showSettings = true)} />
-
   <div class="flex flex-1 overflow-hidden">
-    <div class="shrink-0 border-r border-graphite-700 bg-graphite-950 overflow-hidden" style="width: {leftPanelWidth}px">
+    <div class="shrink-0 border-r border-border-default/50 overflow-hidden" style="width: {leftPanelWidth}px; background: var(--gradient-panel), var(--surface-panel); box-shadow: inset -1px 0 0 var(--border-subtle)">
       <FileTree
         onFileSelect={handleFileSelect}
         selectedPath={editor.currentFilePath}
@@ -187,7 +191,7 @@
 
     <ResizeHandle onResize={resizeLeft} />
 
-    <div class="flex-1 min-w-[200px] overflow-hidden">
+    <div class="flex-1 min-w-[200px] overflow-hidden" style="box-shadow: var(--shadow-xs)">
       <Editor
         bind:ref={editorRef}
         onSelectionChange={handleSelectionChange}
@@ -196,8 +200,8 @@
 
     <ResizeHandle onResize={resizeRight} />
 
-    <div class="shrink-0 border-l border-graphite-700 overflow-hidden" style="width: {rightPanelWidth}px">
-      <AnnotationSidebar onAnnotationClick={handleAnnotationClick} />
+    <div class="shrink-0 border-l border-border-default/50 overflow-hidden" style="width: {rightPanelWidth}px; background: var(--gradient-panel), var(--surface-panel); box-shadow: inset 1px 0 0 var(--border-subtle)">
+      <AnnotationSidebar onAnnotationClick={handleAnnotationClick} onFileSelect={handleFileSelect} />
     </div>
   </div>
 

--- a/src/app.css
+++ b/src/app.css
@@ -1,105 +1,102 @@
 @import "tailwindcss";
 
-/* Flowbite Svelte component styles */
-@plugin "flowbite/plugin";
+/* ── Semantic design tokens ── */
+:root {
+  /* Surfaces */
+  --surface-base: #0E0F11;
+  --surface-panel: #131417;
+  --surface-editor: #1A1C21;
+  --surface-raised: #22252B;
+  --surface-highlight: #2A2D35;
+  --surface-selection: #2A1E1E;
 
-/* Warm graphite + amber palette for Tailwind */
-@theme {
-  --color-graphite-50: #F3EEE7;
-  --color-graphite-100: #E5DDD2;
-  --color-graphite-200: #C8B9A9;
-  --color-graphite-300: #A89A8A;
-  --color-graphite-400: #8C7E70;
-  --color-graphite-500: #6B5E52;
-  --color-graphite-600: #4A4038;
-  --color-graphite-700: #342E27;
-  --color-graphite-800: #2A2420;
-  --color-graphite-900: #1E1B17;
-  --color-graphite-950: #171512;
+  /* Text */
+  --text-primary: #F0F1F3;
+  --text-secondary: #B3B7BF;
+  --text-muted: #6B7280;
 
-  --color-amber-50: #FFF8EB;
-  --color-amber-100: #FDECC8;
-  --color-amber-200: #F5D590;
-  --color-amber-300: #F0AE4A;
-  --color-amber-400: #E39A2D;
-  --color-amber-500: #D08A1F;
-  --color-amber-600: #B47218;
-  --color-amber-700: #8C5712;
-  --color-amber-800: #6B420E;
-  --color-amber-900: #4A2D0A;
-  --color-amber-950: #2A1A06;
+  /* Borders */
+  --border-default: #2B2E36;
+  --border-subtle: rgba(255, 255, 255, 0.03);
+  --border-emphasis: #3B3F4A;
 
-  /* Map primary color to amber for Flowbite */
-  --color-primary-50: var(--color-amber-50);
-  --color-primary-100: var(--color-amber-100);
-  --color-primary-200: var(--color-amber-200);
-  --color-primary-300: var(--color-amber-300);
-  --color-primary-400: var(--color-amber-400);
-  --color-primary-500: var(--color-amber-500);
-  --color-primary-600: var(--color-amber-600);
-  --color-primary-700: var(--color-amber-700);
-  --color-primary-800: var(--color-amber-800);
-  --color-primary-900: var(--color-amber-900);
-  --color-primary-950: var(--color-amber-950);
+  /* Accent */
+  --accent: #F47A63;
+  --accent-hover: #FF9E87;
+  --accent-subtle: rgba(244, 122, 99, 0.12);
+  --accent-annotation-border: rgba(244, 122, 99, 0.45);
 
-  /* Semantic colors */
+  /* Status */
   --color-success: #74B97A;
   --color-warning: #E3B341;
   --color-danger: #D96B5F;
+  --accent-purple: #B07ACC;
+  --accent-teal: #6FA39B;
+  --accent-blue: #5B9BD5;
 
-  /* Surface tokens — CSS variables for direct use */
-  --color-surface-base: #0F0E0C;
-  --color-surface-panel: #171512;
-  --color-surface-editor: #1E1B17;
-  --color-surface-highlight: #2A2420;
-  --color-surface-selection: #3A2A18;
+  /* Elevation */
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.2);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3), 0 2px 6px rgba(0, 0, 0, 0.15);
+  --shadow-card-hover: 0 2px 4px rgba(0, 0, 0, 0.35), 0 4px 12px rgba(0, 0, 0, 0.2);
+  --shadow-panel: 0 1px 3px rgba(0, 0, 0, 0.4), 0 4px 12px rgba(0, 0, 0, 0.25);
+  --shadow-popover: 0 4px 16px rgba(0, 0, 0, 0.5), 0 8px 32px rgba(0, 0, 0, 0.3);
+  --shadow-inset: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+
+  /* Gradients */
+  --gradient-panel: linear-gradient(180deg, rgba(255, 255, 255, 0.02) 0%, transparent 100%);
+  --gradient-toolbar: linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0.01) 100%);
+
+  /* Typography */
+  --font-mono: "SF Mono", "Fira Code", "JetBrains Mono", "Cascadia Code", monospace;
+
+  color-scheme: dark;
+}
+
+/* ── Tailwind theme integration ── */
+@theme {
+  /* Surfaces */
+  --color-surface-base: var(--surface-base);
+  --color-surface-panel: var(--surface-panel);
+  --color-surface-editor: var(--surface-editor);
+  --color-surface-raised: var(--surface-raised);
+  --color-surface-highlight: var(--surface-highlight);
+  --color-surface-selection: var(--surface-selection);
+
+  /* Accent */
+  --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-hover);
+  --color-accent-subtle: var(--accent-subtle);
+
+  /* Text */
+  --color-text-primary: var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
+  --color-text-muted: var(--text-muted);
+
+  /* Borders */
+  --color-border-default: var(--border-default);
+  --color-border-subtle: var(--border-subtle);
+  --color-border-emphasis: var(--border-emphasis);
+
+  /* Status */
+  --color-success: var(--color-success);
+  --color-warning: var(--color-warning);
+  --color-danger: var(--color-danger);
+
+  /* Extended accents */
+  --color-accent-purple: var(--accent-purple);
+  --color-accent-teal: var(--accent-teal);
+  --color-accent-blue: var(--accent-blue);
 
   /* Font families */
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", sans-serif;
   --font-mono: "SF Mono", "Fira Code", "JetBrains Mono", "Cascadia Code", monospace;
 }
 
-/* ── Legacy CSS variable aliases (used by CodeMirror theme + components mid-migration) ── */
-:root {
-  --bg-primary: #0F0E0C;
-  --bg-panel: #171512;
-  --bg-editor: #1E1B17;
-  --bg-surface: var(--bg-panel);
-  --bg-highlight: #2A2420;
-  --bg-selection: #3A2A18;
-  --border-color: #342E27;
-
-  --text-primary: #F3EEE7;
-  --text-secondary: #C8B9A9;
-  --text-subtle: var(--text-secondary);
-  --text-muted: #8C7E70;
-
-  --accent: #E39A2D;
-  --accent-hover: #F0AE4A;
-  --accent-subtle: rgba(227, 154, 45, 0.12);
-  --focus-ring: #F5B24F;
-
-  --accent-green: #74B97A;
-  --accent-yellow: #E3B341;
-  --accent-red: #D96B5F;
-  --accent-purple: #B07ACC;
-  --accent-teal: #6FA39B;
-  --accent-blue: var(--accent);
-
-  --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", sans-serif;
-  --font-size-xs: 11px;
-  --font-size-sm: 12px;
-  --font-size-base: 14px;
-  --font-size-lg: 16px;
-
-  color-scheme: dark;
-}
-
 /* ── Base styles ── */
 body {
-  font-family: var(--font-ui);
-  font-size: var(--font-size-base);
-  background: var(--bg-primary);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  background: var(--surface-base);
   color: var(--text-primary);
   height: 100vh;
   overflow: hidden;
@@ -124,15 +121,10 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--border-color);
+  background: var(--border-default);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--text-muted);
-}
-
-/* ── Flowbite dark mode override — force dark always ── */
-:root {
-  color-scheme: dark;
 }

--- a/src/components/AnnotationCard.svelte
+++ b/src/components/AnnotationCard.svelte
@@ -17,9 +17,9 @@
 </script>
 
 <div
-  class="group px-3 py-2.5 my-0.5 cursor-pointer transition-all border-l-[3px] rounded-r-md
-    {isSelected ? 'bg-[var(--bg-selection)] border-l-amber-400' : 'border-l-graphite-700 hover:bg-graphite-800'}
-    {annotation.isOrphaned ? 'border-l-red-400 opacity-60' : ''}"
+  class="group px-3 py-2.5 my-1 cursor-pointer transition-all duration-150 border-l-[3px] rounded-md
+    {isSelected ? 'bg-surface-selection border-l-accent annotation-card-selected' : 'border-l-border-default/60 hover:bg-surface-highlight/70 annotation-card'}
+    {annotation.isOrphaned ? 'border-l-danger opacity-60' : ''}"
   onclick={onClick}
   ondblclick={onDoubleClick}
   role="button"
@@ -27,14 +27,14 @@
   onkeydown={(e) => e.key === "Enter" && onClick()}
 >
   <div class="flex items-center gap-2 mb-1.5">
-    <span class="text-[11px] text-graphite-400 font-mono">
+    <span class="text-xs text-text-secondary font-mono">
       L{annotation.anchor.range.startLine}
     </span>
     {#if annotation.isOrphaned}
-      <span class="text-[10px] text-red-400 font-semibold uppercase tracking-wide">orphaned</span>
+      <span class="text-xs text-danger font-semibold uppercase tracking-wide">orphaned</span>
     {/if}
     <button
-      class="ml-auto text-base text-graphite-400 opacity-0 group-hover:opacity-100 transition-opacity hover:text-red-400 leading-none"
+      class="ml-auto text-base text-text-secondary opacity-0 group-hover:opacity-100 transition-opacity hover:text-danger leading-none"
       onclick={(e) => { e.stopPropagation(); onDelete(); }}
       title="Delete"
     >
@@ -42,17 +42,32 @@
     </button>
   </div>
 
-  <div class="text-[13px] leading-relaxed mb-1.5 whitespace-pre-wrap break-words text-graphite-50">
+  <div class="text-base leading-relaxed mb-1.5 whitespace-pre-wrap break-words text-text-primary">
     {annotation.body}
   </div>
 
   {#if annotation.labels.length > 0}
     <div class="flex flex-wrap gap-1 mb-1.5">
       {#each annotation.labels as label}
-        <span class="text-[10px] px-2 py-0.5 rounded-full bg-graphite-900 text-graphite-200 border border-graphite-700">{label}</span>
+        <span class="text-xs px-2 py-0.5 rounded-full bg-surface-panel/80 text-text-primary border border-border-default/50" style="box-shadow: var(--shadow-xs)">{label}</span>
       {/each}
     </div>
   {/if}
 
-  <div class="text-[11px] text-graphite-400">{annotation.author}</div>
+  <div class="text-xs text-text-secondary">{annotation.author}</div>
 </div>
+
+<style>
+  .annotation-card {
+    box-shadow: var(--shadow-card);
+    background: var(--gradient-panel), var(--surface-panel);
+  }
+  .annotation-card:hover {
+    box-shadow: var(--shadow-card-hover);
+    transform: translateY(-0.5px);
+  }
+  .annotation-card-selected {
+    box-shadow: var(--shadow-card-hover), 0 0 0 1px rgba(227, 154, 45, 0.15);
+    background: linear-gradient(180deg, rgba(227, 154, 45, 0.04) 0%, transparent 100%), var(--surface-selection);
+  }
+</style>

--- a/src/components/AnnotationPopover.svelte
+++ b/src/components/AnnotationPopover.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Button, Kbd } from "flowbite-svelte";
+  import Kbd from "./ui/Kbd.svelte";
+  import Button from "./ui/Button.svelte";
 
   let {
     onSubmit,
@@ -43,8 +44,8 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <div class="fixed inset-0 z-[99]" onclick={onCancel}></div>
 <div
-  class="fixed z-[100] bg-graphite-950 border border-graphite-700 rounded-xl p-3.5 w-[340px] shadow-2xl flex flex-col gap-2.5"
-  style="left: {position.x}px; top: {position.y}px"
+  class="fixed z-[100] border border-border-default/60 rounded-xl p-3.5 w-[340px] flex flex-col gap-2.5 backdrop-blur-sm"
+  style="left: {position.x}px; top: {position.y}px; background: var(--gradient-panel), var(--surface-panel); box-shadow: var(--shadow-popover), 0 0 0 1px var(--border-subtle)"
   onkeydown={handleKeydown}
   role="dialog"
   tabindex="-1"
@@ -54,21 +55,23 @@
     bind:value={body}
     placeholder="Add your annotation..."
     rows="3"
-    class="w-full bg-graphite-900 border-graphite-700 text-graphite-50 text-sm rounded-md p-2 resize-y min-h-[70px] focus:border-amber-400 focus:ring-amber-400/20"
+    class="w-full bg-surface-panel border-border-default/60 text-text-primary text-sm rounded-md p-2 resize-y min-h-[70px] focus:border-accent focus:ring-accent/20"
+    style="box-shadow: var(--shadow-inset)"
   ></textarea>
 
   <input
     type="text"
     bind:value={labelsInput}
     placeholder="Labels (comma-separated)"
-    class="w-full bg-graphite-900 border-graphite-700 text-graphite-50 text-sm rounded-md p-2 focus:border-amber-400 focus:ring-amber-400/20"
+    class="w-full bg-surface-panel border-border-default/60 text-text-primary text-sm rounded-md p-2 focus:border-accent focus:ring-accent/20"
+    style="box-shadow: var(--shadow-inset)"
   />
 
   <div class="flex justify-end gap-2">
-    <Button size="xs" color="alternative" onclick={onCancel}>Cancel</Button>
-    <Button size="xs" color="primary" onclick={handleSubmit} class="gap-2">
+    <Button variant="secondary" size="sm" onclick={onCancel}>Cancel</Button>
+    <Button size="sm" onclick={handleSubmit}>
       Save
-      <Kbd class="!px-1 !py-0 !text-[10px] opacity-70">Cmd+Return</Kbd>
+      <kbd class="text-xs opacity-60 font-mono">Cmd+Return</kbd>
     </Button>
   </div>
 </div>

--- a/src/components/AnnotationSidebar.svelte
+++ b/src/components/AnnotationSidebar.svelte
@@ -5,20 +5,27 @@
     selectAnnotation,
     removeAnnotation,
     editAnnotation,
+    setSidebarView,
+    loadProjectAnnotations,
   } from "$lib/stores/annotations.svelte";
   import { getEditor } from "$lib/stores/editor.svelte";
-  import { Button, Kbd } from "flowbite-svelte";
+  import { getWorkspace } from "$lib/stores/workspace.svelte";
+  import Kbd from "./ui/Kbd.svelte";
+  import Button from "./ui/Button.svelte";
   import { invoke } from "@tauri-apps/api/core";
   import AnnotationCard from "./AnnotationCard.svelte";
 
   let {
     onAnnotationClick,
+    onFileSelect,
   }: {
     onAnnotationClick: (line: number) => void;
+    onFileSelect?: (path: string) => void;
   } = $props();
 
   const annotationsState = getAnnotationsState();
   const editor = getEditor();
+  const workspace = getWorkspace();
 
   let editingId: string | null = $state(null);
   let editBody = $state("");
@@ -52,72 +59,175 @@
     editingId = null;
   }
 
+  function switchView(view: "file" | "project") {
+    setSidebarView(view);
+    if (view === "project" && workspace.rootFolders.length > 0) {
+      loadProjectAnnotations(workspace.rootFolders[0]);
+    }
+  }
+
+  function handleProjectAnnotationClick(filePath: string, line: number) {
+    if (onFileSelect && filePath !== editor.currentFilePath) {
+      onFileSelect(filePath);
+      // Wait for file to load, then scroll
+      setTimeout(() => onAnnotationClick(line), 200);
+    } else {
+      onAnnotationClick(line);
+    }
+  }
+
   let annotations = $derived(sortedAnnotations());
+
+  let totalProjectAnnotations = $derived(
+    annotationsState.projectAnnotations.reduce((sum, f) => sum + f.annotations.length, 0)
+  );
 </script>
 
-<div class="h-full flex flex-col bg-graphite-950">
-  {#if editor.currentFilePath && annotations.length > 0}
-    <div class="px-2 py-1.5 border-b border-graphite-700">
-      <Button
-        size="xs"
-        color={reviewDone ? "green" : "primary"}
-        class="w-full"
-        onclick={handleDoneReviewing}
-        disabled={reviewDone}
-      >
-        {reviewDone ? "Review sent!" : "Done Reviewing"}
-      </Button>
+<div class="h-full flex flex-col">
+  <!-- View toggle -->
+  <div class="flex border-b border-border-default/60" style="box-shadow: var(--shadow-xs)">
+    <button
+      class="flex-1 px-3 py-2 text-xs font-medium transition-colors relative
+        {annotationsState.sidebarView === 'file'
+          ? 'text-text-primary'
+          : 'text-text-secondary hover:text-text-primary'}"
+      onclick={() => switchView('file')}
+    >
+      Current File
+      {#if annotations.length > 0}
+        <span class="ml-1 text-xs font-mono px-1 py-px rounded bg-surface-raised text-text-secondary">{annotations.length}</span>
+      {/if}
+      {#if annotationsState.sidebarView === 'file'}
+        <span class="absolute bottom-0 left-2 right-2 h-0.5 bg-accent rounded-full"></span>
+      {/if}
+    </button>
+    <button
+      class="flex-1 px-3 py-2 text-xs font-medium transition-colors relative
+        {annotationsState.sidebarView === 'project'
+          ? 'text-text-primary'
+          : 'text-text-secondary hover:text-text-primary'}"
+      onclick={() => switchView('project')}
+    >
+      All Files
+      {#if totalProjectAnnotations > 0}
+        <span class="ml-1 text-xs font-mono px-1 py-px rounded bg-surface-raised text-text-secondary">{totalProjectAnnotations}</span>
+      {/if}
+      {#if annotationsState.sidebarView === 'project'}
+        <span class="absolute bottom-0 left-2 right-2 h-0.5 bg-accent rounded-full"></span>
+      {/if}
+    </button>
+  </div>
+
+  <!-- Current file view -->
+  {#if annotationsState.sidebarView === 'file'}
+    <div class="flex-1 overflow-y-auto px-1.5 py-1">
+      {#each annotations as annotation (annotation.id)}
+        {#if editingId === annotation.id}
+          <div class="p-2.5 my-1 flex flex-col gap-2 rounded-md" style="background: var(--gradient-panel), var(--surface-base); box-shadow: var(--shadow-card)">
+            <textarea
+              bind:value={editBody}
+              rows="3"
+              class="w-full bg-surface-panel border-border-default/60 text-text-primary text-sm rounded-md p-2 focus:border-accent focus:ring-accent/20"
+              style="box-shadow: var(--shadow-inset)"
+            ></textarea>
+            <div class="flex justify-end gap-1.5">
+              <Button variant="secondary" size="sm" onclick={() => (editingId = null)}>Cancel</Button>
+              <Button size="sm" onclick={saveEdit}>Save</Button>
+            </div>
+          </div>
+        {:else}
+          <AnnotationCard
+            {annotation}
+            isSelected={annotationsState.selectedAnnotationId === annotation.id}
+            onClick={() => handleClick(annotation.id, annotation.anchor.range.startLine)}
+            onDoubleClick={() => handleDoubleClick(annotation.id, annotation.body)}
+            onDelete={() => handleDelete(annotation.id)}
+          />
+        {/if}
+      {/each}
+
+      {#if annotations.length === 0}
+        <div class="flex flex-col items-center justify-center px-5 py-10 gap-2 h-full min-h-[200px]">
+          {#if !editor.currentFilePath}
+            <svg class="text-text-secondary opacity-40 mb-1" width="32" height="32" viewBox="0 0 24 24" fill="none">
+              <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" stroke="currentColor" stroke-width="1.5"/>
+              <path d="M14 2v6h6M12 18v-6M9 15h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+            <p class="text-sm font-medium text-text-primary">No file selected</p>
+            <p class="text-xs text-text-secondary text-center">Open a file from the tree to start annotating</p>
+          {:else}
+            <svg class="text-text-secondary opacity-40 mb-1" width="32" height="32" viewBox="0 0 24 24" fill="none">
+              <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="currentColor" stroke-width="1.5"/>
+            </svg>
+            <p class="text-sm font-medium text-text-primary">No annotations yet</p>
+            <p class="text-xs text-text-secondary text-center">Select text in the editor, then</p>
+            <div class="flex items-center gap-1 my-1 text-xs text-text-secondary">
+              <Kbd>Cmd</Kbd>
+              <span>+</span>
+              <Kbd>Return</Kbd>
+            </div>
+            <p class="text-xs text-text-secondary text-center">to add a comment</p>
+          {/if}
+        </div>
+      {/if}
+    </div>
+
+  <!-- Project-wide view -->
+  {:else}
+    <div class="flex-1 overflow-y-auto">
+      {#if annotationsState.projectAnnotationsLoading}
+        <div class="flex items-center justify-center py-10 text-xs text-text-secondary">
+          Loading annotations...
+        </div>
+      {:else if annotationsState.projectAnnotations.length === 0}
+        <div class="flex flex-col items-center justify-center px-5 py-10 gap-2 h-full min-h-[200px]">
+          <svg class="text-text-secondary opacity-40 mb-1" width="32" height="32" viewBox="0 0 24 24" fill="none">
+            <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="currentColor" stroke-width="1.5"/>
+          </svg>
+          <p class="text-sm font-medium text-text-primary">No annotations in project</p>
+          <p class="text-xs text-text-secondary text-center">Annotate files to see them here</p>
+        </div>
+      {:else}
+        {#each annotationsState.projectAnnotations as fileGroup (fileGroup.filePath)}
+          <div class="border-b border-border-default/40">
+            <button
+              class="w-full flex items-center gap-2 px-3 py-1.5 text-left hover:bg-surface-highlight/50 transition-colors
+                {fileGroup.filePath === editor.currentFilePath ? 'bg-surface-highlight/30' : ''}"
+              onclick={() => onFileSelect?.(fileGroup.filePath)}
+            >
+              <span class="text-xs font-medium text-text-primary truncate flex-1">{fileGroup.fileName}</span>
+              <span class="text-xs font-mono px-1.5 py-0.5 rounded bg-surface-raised text-text-secondary shrink-0">{fileGroup.annotations.length}</span>
+            </button>
+            <div class="px-1.5 pb-1">
+              {#each fileGroup.annotations as annotation (annotation.id)}
+                <div
+                  class="group px-2.5 py-1.5 my-0.5 cursor-pointer rounded text-sm text-text-secondary hover:bg-surface-highlight/50 transition-colors truncate"
+                  onclick={() => handleProjectAnnotationClick(fileGroup.filePath, annotation.anchor.range.startLine)}
+                  role="button"
+                  tabindex="0"
+                  onkeydown={(e) => e.key === "Enter" && handleProjectAnnotationClick(fileGroup.filePath, annotation.anchor.range.startLine)}
+                >
+                  <span class="text-xs text-text-muted font-mono mr-1.5">L{annotation.anchor.range.startLine}</span>
+                  {annotation.body}
+                </div>
+              {/each}
+            </div>
+          </div>
+        {/each}
+      {/if}
     </div>
   {/if}
 
-  <div class="flex-1 overflow-y-auto px-1.5 py-1">
-    {#each annotations as annotation (annotation.id)}
-      {#if editingId === annotation.id}
-        <div class="p-2.5 my-1 flex flex-col gap-2 bg-[var(--bg-primary)] rounded-md">
-          <textarea
-            bind:value={editBody}
-            rows="3"
-            class="w-full bg-graphite-900 border-graphite-700 text-graphite-50 text-sm rounded-md p-2 focus:border-amber-400 focus:ring-amber-400/20"
-          ></textarea>
-          <div class="flex justify-end gap-1.5">
-            <Button size="xs" color="alternative" onclick={() => (editingId = null)}>Cancel</Button>
-            <Button size="xs" color="primary" onclick={saveEdit}>Save</Button>
-          </div>
-        </div>
+  <!-- Bottom action bar -->
+  {#if annotationsState.sidebarView === 'file' && editor.currentFilePath && annotations.length > 0}
+    <div class="px-2.5 py-2 border-t border-border-default/60" style="box-shadow: var(--shadow-xs)">
+      {#if reviewDone}
+        <Button variant="secondary" disabled class="w-full bg-success/20 text-success border-success/30">Review sent!</Button>
       {:else}
-        <AnnotationCard
-          {annotation}
-          isSelected={annotationsState.selectedAnnotationId === annotation.id}
-          onClick={() => handleClick(annotation.id, annotation.anchor.range.startLine)}
-          onDoubleClick={() => handleDoubleClick(annotation.id, annotation.body)}
-          onDelete={() => handleDelete(annotation.id)}
-        />
+        <Button onclick={handleDoneReviewing} class="w-full">
+          Send {annotations.length} {annotations.length === 1 ? 'annotation' : 'annotations'}
+        </Button>
       {/if}
-    {/each}
-
-    {#if annotations.length === 0}
-      <div class="flex flex-col items-center justify-center px-5 py-10 gap-2 h-full min-h-[200px]">
-        {#if !editor.currentFilePath}
-          <svg class="text-graphite-400 opacity-40 mb-1" width="32" height="32" viewBox="0 0 24 24" fill="none">
-            <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" stroke="currentColor" stroke-width="1.5"/>
-            <path d="M14 2v6h6M12 18v-6M9 15h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-          </svg>
-          <p class="text-sm font-medium text-graphite-200">No file selected</p>
-          <p class="text-xs text-graphite-400 text-center">Open a file from the tree to start annotating</p>
-        {:else}
-          <svg class="text-graphite-400 opacity-40 mb-1" width="32" height="32" viewBox="0 0 24 24" fill="none">
-            <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" stroke="currentColor" stroke-width="1.5"/>
-          </svg>
-          <p class="text-sm font-medium text-graphite-200">No annotations yet</p>
-          <p class="text-xs text-graphite-400 text-center">Select text in the editor, then</p>
-          <div class="flex items-center gap-1 my-1 text-xs text-graphite-400">
-            <Kbd class="!px-1.5 !py-0.5 !text-[11px]">Cmd</Kbd>
-            <span>+</span>
-            <Kbd class="!px-1.5 !py-0.5 !text-[11px]">Return</Kbd>
-          </div>
-          <p class="text-xs text-graphite-400 text-center">to add a comment</p>
-        {/if}
-      </div>
-    {/if}
-  </div>
+    </div>
+  {/if}
 </div>

--- a/src/components/FileTree.svelte
+++ b/src/components/FileTree.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { open } from "@tauri-apps/plugin-dialog";
-  import { getWorkspace, addRootFolder, removeRootFolder, toggleShowChangedOnly, getChangedFilePaths } from "$lib/stores/workspace.svelte";
+  import { getWorkspace, addRootFolder, removeRootFolder, toggleShowChangedOnly, getChangedFilePaths, expandAllFolders, collapseAllFolders } from "$lib/stores/workspace.svelte";
   import FileTreeItem from "./FileTreeItem.svelte";
+  import IconButton from "./ui/IconButton.svelte";
 
   let {
     onFileSelect,
@@ -80,27 +81,31 @@
 
 <div class="h-full overflow-y-auto overflow-x-hidden" role="tree">
   {#if workspace.rootFolders.length > 0}
-    <div class="flex items-center justify-between px-3 py-1.5 border-b border-graphite-700">
-      <span class="text-[10px] font-semibold uppercase text-graphite-500 tracking-wider">Folders</span>
+    <div class="flex items-center justify-between px-3 py-1.5 border-b border-border-default">
+      <span class="text-xs font-semibold uppercase text-text-muted tracking-wider">Folders</span>
       <div class="flex items-center gap-1.5">
-        <button
-          class="transition-colors {workspace.showChangedOnly ? 'text-amber-400' : 'text-graphite-400 hover:text-graphite-200'}"
-          onclick={toggleShowChangedOnly}
-          title={workspace.showChangedOnly ? "Show all files" : "Show changed files only"}
-        >
+        <IconButton label="Expand all" onclick={expandAllFolders}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M7 8l5 5 5-5" />
+            <path d="M7 13l5 5 5-5" />
+          </svg>
+        </IconButton>
+        <IconButton label="Collapse all" onclick={collapseAllFolders}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M7 16l5-5 5 5" />
+            <path d="M7 11l5-5 5 5" />
+          </svg>
+        </IconButton>
+        <IconButton label={workspace.showChangedOnly ? "Show all files" : "Changed only"} active={workspace.showChangedOnly} onclick={toggleShowChangedOnly}>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
             <path d="M12 20h9M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z" />
           </svg>
-        </button>
-        <button
-          class="text-graphite-400 hover:text-graphite-200 transition-colors"
-          onclick={openFolder}
-          title="Add folder"
-        >
+        </IconButton>
+        <IconButton label="Add folder" onclick={openFolder}>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
             <path d="M12 5v14M5 12h14" />
           </svg>
-        </button>
+        </IconButton>
       </div>
     </div>
   {/if}
@@ -112,11 +117,11 @@
       <div>
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
-          class="flex items-center gap-1 px-3 py-1.5 text-[11px] font-semibold uppercase text-graphite-400 tracking-wider select-none cursor-pointer hover:text-graphite-200 transition-colors"
+          class="flex items-center gap-1 px-3 py-1.5 text-xs font-semibold uppercase text-text-secondary tracking-wider select-none cursor-pointer hover:text-text-primary transition-colors"
           onclick={() => toggleRoot(folder)}
           oncontextmenu={(e) => handleContextMenu(e, folder)}
         >
-          <span class="text-[10px]">{collapsedRoots.has(folder) ? "▸" : "▾"}</span>
+          <span class="text-xs">{collapsedRoots.has(folder) ? "▸" : "▾"}</span>
           {folder.split("/").pop()}
         </div>
         {#if !collapsedRoots.has(folder)}
@@ -131,7 +136,7 @@
   {#if workspace.rootFolders.length === 0}
     <div class="flex justify-center p-6">
       <button
-        class="px-4 py-1.5 rounded-md text-sm font-semibold bg-amber-400 text-graphite-950 hover:bg-amber-300 transition-colors"
+        class="px-4 py-1.5 rounded-md text-sm font-semibold bg-accent text-surface-base hover:bg-accent-hover transition-colors"
         onclick={openFolder}
       >
         Open Folder
@@ -145,27 +150,27 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div class="fixed inset-0 z-40" onclick={closeContextMenu}></div>
   <div
-    class="fixed z-50 min-w-[160px] py-1 bg-graphite-900 border border-graphite-700 rounded-lg shadow-xl"
-    style="left: {contextMenuPos.x}px; top: {contextMenuPos.y}px"
+    class="fixed z-50 min-w-[160px] py-1 border border-border-default/60 rounded-lg backdrop-blur-sm"
+    style="left: {contextMenuPos.x}px; top: {contextMenuPos.y}px; background: var(--gradient-panel), var(--surface-raised); box-shadow: var(--shadow-popover), 0 0 0 1px var(--border-subtle)"
     role="menu"
   >
     <button
-      class="w-full text-left px-3 py-1.5 text-xs text-graphite-50 hover:bg-graphite-800 transition-colors"
+      class="w-full text-left px-3 py-1.5 text-xs text-text-primary hover:bg-surface-highlight transition-colors"
       onclick={handleOpenInFinder}
       role="menuitem"
     >
       Open in Finder
     </button>
     <button
-      class="w-full text-left px-3 py-1.5 text-xs text-graphite-50 hover:bg-graphite-800 transition-colors"
+      class="w-full text-left px-3 py-1.5 text-xs text-text-primary hover:bg-surface-highlight transition-colors"
       onclick={handleCollapseAll}
       role="menuitem"
     >
       Collapse All
     </button>
-    <div class="my-1 border-t border-graphite-700"></div>
+    <div class="my-1 border-t border-border-default"></div>
     <button
-      class="w-full text-left px-3 py-1.5 text-xs text-red-400 hover:bg-graphite-800 transition-colors"
+      class="w-full text-left px-3 py-1.5 text-xs text-danger hover:bg-surface-highlight transition-colors"
       onclick={handleRemoveFolder}
       role="menuitem"
     >

--- a/src/components/FileTreeItem.svelte
+++ b/src/components/FileTreeItem.svelte
@@ -35,20 +35,20 @@
 
   function gitStatusClass(status: string): string {
     switch (status) {
-      case "M": return "text-amber-300";
-      case "A": return "text-green-400";
-      case "?": return "text-teal-400";
-      case "D": return "text-red-400";
-      case "R": return "text-purple-400";
-      default: return "text-graphite-400";
+      case "M": return "text-warning";
+      case "A": return "text-success";
+      case "?": return "text-accent-teal";
+      case "D": return "text-danger";
+      case "R": return "text-accent-purple";
+      default: return "text-text-secondary";
     }
   }
 </script>
 
 <div
   class="flex items-center gap-1.5 py-1 pr-3 cursor-pointer text-xs whitespace-nowrap select-none min-h-7 transition-colors
-    {isSelected ? 'bg-[var(--bg-selection)] text-amber-400' : entry.isDir ? 'text-graphite-50 font-medium' : 'text-graphite-200'}
-    {!isSelected ? 'hover:bg-graphite-800 hover:text-graphite-50' : ''}"
+    {isSelected ? 'bg-surface-selection text-accent' : entry.isDir ? 'text-text-primary font-medium' : 'text-text-primary'}
+    {!isSelected ? 'hover:bg-surface-highlight hover:text-text-primary' : ''}"
   style="padding-left: {depth * 18 + 12}px"
   onclick={handleClick}
   role="treeitem"
@@ -58,18 +58,24 @@
 >
   <span class="w-3.5 flex items-center justify-center shrink-0">
     {#if entry.isDir}
-      <span class="text-[10px] text-graphite-400">{isExpanded ? "▾" : "▸"}</span>
+      <span class="text-xs text-text-secondary">{isExpanded ? "▾" : "▸"}</span>
     {:else}
-      <span class="w-1 h-1 rounded-full bg-graphite-400 opacity-50"></span>
+      <span class="w-1 h-1 rounded-full bg-border-emphasis opacity-50"></span>
     {/if}
   </span>
   <span class="overflow-hidden text-ellipsis">{entry.name}</span>
-  {#if entry.hasSidecar}
-    <span class="w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0 opacity-80"></span>
-  {/if}
-  {#if gitStatus}
-    <span class="text-[11px] font-semibold ml-auto shrink-0 font-mono {gitStatusClass(gitStatus.status)}">{gitStatus.status}</span>
-  {/if}
+  <div class="flex items-center gap-1.5 ml-auto shrink-0">
+    {#if entry.hasSidecar}
+      <span class="flex items-center gap-0.5 text-xs font-semibold tracking-wide uppercase px-1 py-px rounded bg-accent-subtle text-accent border border-accent/20">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+          <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/>
+        </svg>
+      </span>
+    {/if}
+    {#if gitStatus}
+      <span class="text-xs font-semibold font-mono {gitStatusClass(gitStatus.status)}">{gitStatus.status}</span>
+    {/if}
+  </div>
 </div>
 
 {#if entry.isDir && isExpanded}

--- a/src/components/FilterBar.svelte
+++ b/src/components/FilterBar.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import type { AnnotationFilter } from "$lib/types";
   import { getAnnotationsState, setFilter } from "$lib/stores/annotations.svelte";
-  import { ButtonGroup, Button } from "flowbite-svelte";
+  import Button from "./ui/Button.svelte";
+
+  type AnnotationFilter = "all" | "comment" | "lineNote" | "label";
 
   const annotationsState = getAnnotationsState();
   let allAnnotations = $derived(annotationsState.sidecar?.annotations ?? []);
@@ -19,18 +20,18 @@
   ];
 </script>
 
-<div class="px-2.5 py-2 border-b border-graphite-700">
-  <ButtonGroup class="w-full">
+<div class="px-2.5 py-2 border-b border-border-default">
+  <div class="flex w-full gap-1">
     {#each filters as f}
       <Button
-        size="xs"
-        color={annotationsState.filter === f.value ? "primary" : "alternative"}
+        variant={annotationsState.filter === f.value ? "primary" : "secondary"}
+        size="sm"
         onclick={() => setFilter(f.value)}
-        class="flex-1 !text-[11px] gap-1"
+        class="flex-1"
       >
         {f.label}
-        <span class="opacity-60 font-mono text-[10px]">{countForFilter(f.value)}</span>
+        <span class="opacity-60 font-mono text-xs">{countForFilter(f.value)}</span>
       </Button>
     {/each}
-  </ButtonGroup>
+  </div>
 </div>

--- a/src/components/ResizeHandle.svelte
+++ b/src/components/ResizeHandle.svelte
@@ -30,7 +30,7 @@
 <div
   class="shrink-0 relative z-10 bg-transparent transition-colors
     {direction === 'horizontal' ? 'w-1 cursor-col-resize -mx-0.5' : 'h-1 cursor-row-resize -my-0.5'}
-    {dragging ? 'bg-amber-400/70' : 'hover:bg-amber-400/40'}"
+    {dragging ? 'bg-accent/70' : 'hover:bg-accent/40'}"
   onpointerdown={onPointerDown}
   onpointermove={onPointerMove}
   onpointerup={onPointerUp}

--- a/src/components/SettingsDialog.svelte
+++ b/src/components/SettingsDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getSettings, updateSettings } from "$lib/tauri";
   import { onMount } from "svelte";
-  import { Button, Label, Input } from "flowbite-svelte";
+  import Button from "./ui/Button.svelte";
 
   let { onClose }: { onClose: () => void } = $props();
 
@@ -31,30 +31,40 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <!-- svelte-ignore a11y_click_events_have_key_events -->
-<div class="fixed inset-0 bg-black/60 flex items-center justify-center z-[200]" onclick={onClose}>
+<div class="fixed inset-0 bg-black/60 backdrop-blur-[2px] flex items-center justify-center z-[200]" onclick={onClose}>
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <div
-    class="bg-graphite-950 border border-graphite-700 rounded-xl p-6 w-[380px] flex flex-col gap-4 shadow-2xl"
+    class="border border-border-default/60 rounded-xl p-6 w-[380px] flex flex-col gap-4"
+    style="background: var(--gradient-panel), var(--surface-panel); box-shadow: var(--shadow-popover), 0 0 0 1px var(--border-subtle)"
     onclick={(e) => e.stopPropagation()}
     onkeydown={handleKeydown}
     role="dialog"
     tabindex="-1"
   >
-    <h3 class="text-base font-semibold text-graphite-50">Settings</h3>
+    <h3 class="text-base font-semibold text-text-primary">Settings</h3>
 
     <div class="flex flex-col gap-1.5">
-      <Label class="!text-xs !text-graphite-200 !font-medium">Author name</Label>
-      <Input bind:value={author} size="sm" class="!bg-graphite-900 !border-graphite-700 !text-graphite-50" />
+      <label class="text-xs text-text-secondary font-medium">Author name</label>
+      <input
+        bind:value={author}
+        class="w-full bg-surface-panel border border-border-default/60 text-text-primary text-sm rounded-md px-2.5 py-1.5 focus:border-accent focus:ring-1 focus:ring-accent/20 outline-none transition-colors"
+        style="box-shadow: var(--shadow-inset)"
+      />
     </div>
 
     <div class="flex flex-col gap-1.5">
-      <Label class="!text-xs !text-graphite-200 !font-medium">Default labels (comma-separated)</Label>
-      <Input bind:value={defaultLabels} size="sm" placeholder="todo, bug, question" class="!bg-graphite-900 !border-graphite-700 !text-graphite-50" />
+      <label class="text-xs text-text-secondary font-medium">Default labels (comma-separated)</label>
+      <input
+        bind:value={defaultLabels}
+        placeholder="todo, bug, question"
+        class="w-full bg-surface-panel border border-border-default/60 text-text-primary text-sm rounded-md px-2.5 py-1.5 focus:border-accent focus:ring-1 focus:ring-accent/20 outline-none transition-colors"
+        style="box-shadow: var(--shadow-inset)"
+      />
     </div>
 
     <div class="flex justify-end gap-2 mt-1">
-      <Button size="xs" color="alternative" onclick={onClose}>Cancel</Button>
-      <Button size="xs" color="primary" onclick={save}>Save</Button>
+      <Button variant="secondary" size="sm" onclick={onClose}>Cancel</Button>
+      <Button size="sm" onclick={save}>Save</Button>
     </div>
   </div>
 </div>

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getWorkspace } from "$lib/stores/workspace.svelte";
-  import { Button } from "flowbite-svelte";
+  import IconButton from "./ui/IconButton.svelte";
 
   let { onSettingsClick }: { onSettingsClick: () => void } = $props();
 
@@ -13,16 +13,16 @@
   );
 </script>
 
-<div class="flex items-center justify-between h-10 pl-[78px] pr-3 bg-[var(--bg-primary)] border-b border-graphite-700" style="-webkit-app-region: drag">
-  <div class="flex items-center gap-2 flex-1" style="-webkit-app-region: no-drag">
-    <span class="text-xs font-semibold text-graphite-200 tracking-wide">{workspaceName}</span>
+<div class="flex items-center justify-between h-10 px-3 border-b border-border-default/60" style="background: var(--gradient-toolbar), var(--surface-base); box-shadow: var(--shadow-xs)">
+  <div class="flex items-center gap-2 flex-1">
+    <span class="text-xs font-semibold text-text-secondary tracking-wide">{workspaceName}</span>
   </div>
-  <div class="flex justify-end" style="-webkit-app-region: no-drag">
-    <Button size="xs" color="alternative" onclick={onSettingsClick} class="!p-1.5">
+  <div class="flex justify-end">
+    <IconButton label="Settings" onclick={onSettingsClick}>
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
         <path d="M8 10a2 2 0 100-4 2 2 0 000 4z" stroke="currentColor" stroke-width="1.5"/>
         <path d="M13.5 8a5.5 5.5 0 01-.3 1.8l1.3 1-1 1.7-1.5-.6a5.5 5.5 0 01-1.5.9L10 14H8l-.5-1.6a5.5 5.5 0 01-1.5-.9l-1.5.6-1-1.7 1.3-1A5.5 5.5 0 014.5 8c0-.6.1-1.2.3-1.8l-1.3-1 1-1.7 1.5.6a5.5 5.5 0 011.5-.9L8 2h2l.5 1.6a5.5 5.5 0 011.5.9l1.5-.6 1 1.7-1.3 1c.2.6.3 1.2.3 1.8z" stroke="currentColor" stroke-width="1.2"/>
       </svg>
-    </Button>
+    </IconButton>
   </div>
 </div>

--- a/src/components/ui/Button.svelte
+++ b/src/components/ui/Button.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+
+  interface Props extends HTMLButtonAttributes {
+    variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+    size?: 'sm' | 'md';
+    disabled?: boolean;
+    class?: string;
+    onclick?: (e: MouseEvent) => void;
+    children: Snippet;
+  }
+
+  let {
+    variant = 'primary',
+    size = 'md',
+    disabled = false,
+    class: className = '',
+    children,
+    ...restProps
+  }: Props = $props();
+
+  const variantStyles: Record<string, string> = {
+    primary: 'bg-accent text-surface-base font-semibold hover:bg-accent-hover',
+    secondary:
+      'bg-surface-raised text-text-secondary border border-border-subtle hover:bg-surface-highlight',
+    ghost: 'text-text-secondary hover:bg-surface-highlight hover:text-text-primary',
+    danger: 'text-danger hover:bg-danger/10',
+  };
+
+  const sizeStyles: Record<string, string> = {
+    sm: 'px-2.5 py-1 text-xs rounded-md',
+    md: 'px-3 py-1.5 text-sm rounded-md',
+  };
+</script>
+
+<button
+  class="transition-colors inline-flex items-center justify-center gap-1.5 focus-visible:ring-1 focus-visible:ring-accent/30 focus-visible:outline-none {variantStyles[variant]} {sizeStyles[size]} {disabled ? 'opacity-50 pointer-events-none' : ''} {className}"
+  {disabled}
+  {...restProps}
+>
+  {@render children()}
+</button>

--- a/src/components/ui/IconButton.svelte
+++ b/src/components/ui/IconButton.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+
+  interface Props extends HTMLButtonAttributes {
+    label: string;
+    class?: string;
+    active?: boolean;
+    onclick?: (e: MouseEvent) => void;
+    children: Snippet;
+  }
+
+  let {
+    label,
+    class: className = '',
+    active = false,
+    children,
+    ...restProps
+  }: Props = $props();
+</script>
+
+<button
+  title={label}
+  aria-label={label}
+  class="inline-flex items-center justify-center p-1 rounded hover:text-text-primary hover:bg-surface-highlight transition-colors {active ? 'text-accent' : 'text-text-secondary'} {className}"
+  {...restProps}
+>
+  {@render children()}
+</button>

--- a/src/components/ui/Kbd.svelte
+++ b/src/components/ui/Kbd.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    class?: string;
+    children: Snippet;
+  }
+
+  let { class: className = '', children }: Props = $props();
+</script>
+
+<kbd
+  class="inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-mono rounded bg-surface-raised text-text-secondary border border-border-default {className}"
+>
+  {@render children()}
+</kbd>

--- a/src/lib/codemirror/annotations.ts
+++ b/src/lib/codemirror/annotations.ts
@@ -77,18 +77,18 @@ const annotationDecorations = EditorView.decorations.compute(
   }
 );
 
-// Gutter marker for annotated lines
+// Gutter marker for annotated lines — vertical bar indicator
 class AnnotationGutterMarker extends GutterMarker {
   constructor(private orphaned: boolean) {
     super();
   }
 
   toDOM() {
-    const dot = document.createElement("span");
-    dot.className = this.orphaned
-      ? "rp-gutter-dot rp-gutter-dot-orphaned"
-      : "rp-gutter-dot";
-    return dot;
+    const bar = document.createElement("span");
+    bar.className = this.orphaned
+      ? "rp-gutter-marker rp-gutter-marker-orphaned"
+      : "rp-gutter-marker";
+    return bar;
   }
 }
 

--- a/src/lib/codemirror/theme.ts
+++ b/src/lib/codemirror/theme.ts
@@ -5,7 +5,7 @@ export const redPenTheme = EditorView.theme({
     height: "100%",
     fontSize: "14px",
     fontFamily: "var(--font-mono)",
-    backgroundColor: "var(--bg-editor)",
+    backgroundColor: "var(--surface-editor)",
   },
   ".cm-content": {
     padding: "8px 0",
@@ -15,8 +15,8 @@ export const redPenTheme = EditorView.theme({
     borderLeftColor: "var(--accent)",
   },
   ".cm-gutters": {
-    backgroundColor: "var(--bg-editor)",
-    borderRight: "1px solid var(--border-color)",
+    backgroundColor: "var(--surface-editor)",
+    borderRight: "1px solid var(--border-default)",
     color: "var(--text-muted)",
     fontSize: "12px",
     minWidth: "48px",
@@ -30,28 +30,37 @@ export const redPenTheme = EditorView.theme({
     opacity: "1",
   },
   ".cm-activeLine": {
-    backgroundColor: "rgba(42, 36, 32, 0.5)",
+    backgroundColor: "color-mix(in srgb, var(--surface-highlight) 50%, transparent)",
   },
   ".cm-selectionBackground, ::selection": {
-    backgroundColor: "var(--bg-selection) !important",
+    backgroundColor: "var(--surface-selection) !important",
   },
   // Annotation highlight
   ".rp-annotation": {
-    backgroundColor: "rgba(227, 154, 45, 0.12)",
-    borderBottom: "2px solid rgba(227, 154, 45, 0.5)",
+    backgroundColor: "var(--accent-subtle)",
+    borderBottom: "2px solid var(--accent-annotation-border)",
   },
   ".rp-annotation-orphaned": {
     backgroundColor: "rgba(217, 107, 95, 0.12)",
     borderBottom: "2px solid rgba(217, 107, 95, 0.5)",
   },
-  // Gutter dots
-  ".rp-gutter-dot": {
-    width: "6px",
-    height: "6px",
-    borderRadius: "50%",
-    display: "inline-block",
-    marginLeft: "6px",
-    backgroundColor: "#E39A2D",
+  // Gutter markers
+  ".rp-annotation-gutter": {
+    width: "14px",
   },
-  ".rp-gutter-dot-orphaned": { backgroundColor: "#D96B5F" },
+  ".rp-gutter-marker": {
+    width: "3px",
+    height: "100%",
+    display: "block",
+    backgroundColor: "var(--accent-annotation-border)",
+    borderRadius: "1px",
+    marginLeft: "5px",
+    transition: "background-color 150ms",
+  },
+  ".rp-gutter-marker:hover": {
+    backgroundColor: "var(--accent)",
+  },
+  ".rp-gutter-marker-orphaned": {
+    backgroundColor: "rgba(217, 107, 95, 0.5)",
+  },
 });

--- a/src/lib/stores/annotations.svelte.ts
+++ b/src/lib/stores/annotations.svelte.ts
@@ -1,14 +1,25 @@
-import { getAnnotations, createAnnotation, updateAnnotation, deleteAnnotation } from "$lib/tauri";
-import type { Annotation, SidecarFile } from "$lib/types";
+import { getAnnotations, createAnnotation, updateAnnotation, deleteAnnotation, getAllAnnotations } from "$lib/tauri";
+import type { Annotation, FileAnnotations, SidecarFile } from "$lib/types";
+
+type AnnotationFilter = "all" | "comment" | "lineNote" | "label";
+type SidebarView = "file" | "project";
 
 interface AnnotationsState {
   sidecar: SidecarFile | null;
   selectedAnnotationId: string | null;
+  filter: AnnotationFilter;
+  sidebarView: SidebarView;
+  projectAnnotations: FileAnnotations[];
+  projectAnnotationsLoading: boolean;
 }
 
 let state = $state<AnnotationsState>({
   sidecar: null,
   selectedAnnotationId: null,
+  filter: "all",
+  sidebarView: "file",
+  projectAnnotations: [],
+  projectAnnotationsLoading: false,
 });
 
 export function getAnnotationsState() {
@@ -21,6 +32,24 @@ export async function loadAnnotations(filePath: string) {
   } catch {
     state.sidecar = null;
   }
+}
+
+export async function loadProjectAnnotations(rootFolder: string) {
+  state.projectAnnotationsLoading = true;
+  try {
+    state.projectAnnotations = await getAllAnnotations(rootFolder);
+  } catch {
+    state.projectAnnotations = [];
+  }
+  state.projectAnnotationsLoading = false;
+}
+
+export function setSidebarView(view: SidebarView) {
+  state.sidebarView = view;
+}
+
+export function setFilter(filter: AnnotationFilter) {
+  state.filter = filter;
 }
 
 export function sortedAnnotations(): Annotation[] {

--- a/src/lib/stores/workspace.svelte.ts
+++ b/src/lib/stores/workspace.svelte.ts
@@ -56,6 +56,29 @@ export function toggleFolder(path: string) {
   }
 }
 
+export async function expandAllFolders() {
+  async function expandRecursive(path: string) {
+    state.expandedFolders.add(path);
+    if (!state.fileTree.has(path)) {
+      await loadDirectory(path);
+    }
+    const entries = state.fileTree.get(path) ?? [];
+    for (const entry of entries) {
+      if (entry.isDir) {
+        await expandRecursive(entry.path);
+      }
+    }
+  }
+
+  for (const root of state.rootFolders) {
+    await expandRecursive(root);
+  }
+}
+
+export function collapseAllFolders() {
+  state.expandedFolders.clear();
+}
+
 export function getGitStatusForFile(filePath: string): GitFileStatus | undefined {
   for (const [, statuses] of state.gitStatuses) {
     const match = statuses.find((s) => filePath.endsWith(s.path));

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { Annotation, FileEntry, GitFileStatus, SidecarFile } from "./types";
+import type { Annotation, FileAnnotations, FileEntry, GitFileStatus, SidecarFile } from "./types";
 
 export async function readDirectory(path: string): Promise<FileEntry[]> {
   return invoke("read_directory", { path });
@@ -35,6 +35,10 @@ export async function updateAnnotation(
 
 export async function deleteAnnotation(filePath: string, annotationId: string): Promise<void> {
   return invoke("delete_annotation", { filePath, annotationId });
+}
+
+export async function getAllAnnotations(rootFolder: string): Promise<FileAnnotations[]> {
+  return invoke("get_all_annotations", { rootFolder });
 }
 
 export async function getGitStatus(directory: string): Promise<GitFileStatus[]> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,6 +43,12 @@ export interface FileEntry {
   hasSidecar: boolean;
 }
 
+export interface FileAnnotations {
+  filePath: string;
+  fileName: string;
+  annotations: Annotation[];
+}
+
 export interface GitFileStatus {
   path: string;
   status: string;


### PR DESCRIPTION
## Summary

- Replace dual token system (legacy CSS vars + Tailwind graphite/coral scales) with single semantic CSS variable layer consumed by Tailwind `@theme` — enables future theme support
- Drop Flowbite; adopt Bits UI for accessible headless primitives
- Create shared UI atoms (`Button`, `Kbd`, `IconButton`) with consistent variants
- Standardize typography to 4-step scale, unify spacing/focus/button patterns, replace 30+ inline `rgba()` with semantic tokens
- Migrate CodeMirror theme to semantic variables

## Test plan

- [ ] Run `bun run build` — passes with no errors
- [ ] Launch app (`bun run tauri dev`) and verify all panels render correctly
- [ ] Verify file tree icons, tooltips, and context menu work
- [ ] Verify annotation creation flow (select text → Cmd+Enter → popover)
- [ ] Verify filter bar toggles in annotation sidebar
- [ ] Verify settings dialog opens and saves
- [ ] Verify CodeMirror annotation highlights and gutter markers display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)