### PR TITLE
ci: remove Apple signing, ship unsigned builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,25 +35,7 @@ jobs:
       - name: Install frontend dependencies
         run: bun install
 
-      - name: Install Apple certificate
-        env:
-          CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          echo "$CERTIFICATE" | base64 --decode > cert.p12
-          security create-keychain -p "" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "" build.keychain
-          security import cert.p12 -k build.keychain -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
-          rm cert.p12
-
       - name: Build Tauri app
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: bun run tauri build --target aarch64-apple-darwin
 
       - name: Build CLI

--- a/README.md
+++ b/README.md
@@ -6,12 +6,21 @@ Built with [Tauri](https://tauri.app), [Svelte 5](https://svelte.dev), and [Code
 
 ## Install
 
+### From Releases
+
+Download the latest `.dmg` from the [Releases](https://github.com/phin-tech/redpen/releases) page.
+
+> **Note:** The app is currently unsigned. macOS will quarantine it on first download. Run the following to clear the quarantine flag:
+> ```bash
+> xattr -dr com.apple.quarantine /Applications/Red\ Pen.app
+> ```
+
 ### From Source
 
 ```bash
-pnpm install
-pnpm tauri build
-cp -R target/release/bundle/macos/Red\ Pen.app /Applications/
+bun install
+bun run tauri build
+cp -R src-tauri/target/release/bundle/macos/Red\ Pen.app /Applications/
 ```
 
 ### CLI
@@ -135,8 +144,8 @@ Syntax highlighting for: JavaScript, TypeScript, JSX, TSX, Python, Rust, Go, Jav
 ## Development
 
 ```bash
-pnpm install
-pnpm tauri dev
+bun install
+bun run tauri dev
 ```
 
 ### Project Structure


### PR DESCRIPTION
## Summary

- Removes Apple certificate installation and all signing env vars (`APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`) from the release workflow
- Updates README to document installing from GitHub Releases with the `xattr -dr com.apple.quarantine` workaround for unsigned builds
- Fixes `pnpm` → `bun` in README install/dev instructions
- Fixes incorrect `cp` path in From Source install steps

## Test plan

- [ ] Trigger a release tag and verify the unsigned DMG builds and uploads successfully
- [ ] Verify `xattr` command in README clears quarantine on the downloaded DMG

🤖 Generated with [Claude Code](https://claude.com/claude-code)