### PR TITLE
fix: delete sidecar file when all annotations are removed

### DIFF
--- a/src-tauri/src/commands/annotations.rs
+++ b/src-tauri/src/commands/annotations.rs
@@ -45,9 +45,15 @@ fn load_sidecar_for_file(project_root: &Path, source_path: &Path) -> Result<Side
 }
 
 fn save_sidecar(sidecar: &SidecarFile, project_root: &Path, source_path: &Path) -> Result<(), String> {
-    sidecar
-        .save_for_source(project_root, source_path)
-        .map_err(|e| e.to_string())
+    let annotation_path = SidecarFile::annotation_path(project_root, source_path);
+    if sidecar.annotations.is_empty() {
+        if annotation_path.exists() {
+            fs::remove_file(&annotation_path).map_err(|e| e.to_string())?;
+        }
+        Ok(())
+    } else {
+        sidecar.save(&annotation_path).map_err(|e| e.to_string())
+    }
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
- When all annotations are deleted from a file (via `delete_annotation` or `clear_annotations`), the empty `.redpen.json` sidecar file is now removed instead of being saved with an empty annotations array
- This prevents the GUI from showing files as annotated when they have no annotations

## Test plan
- [ ] Delete all annotations from a file and verify the sidecar JSON file is removed
- [ ] Verify the file no longer appears as annotated in the file tree
- [ ] Verify adding new annotations after clearing still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)