### PR TITLE
fix: resolve push approval signal path in git worktrees

### DIFF
--- a/plugin/hooks/scripts/check-git-push.sh
+++ b/plugin/hooks/scripts/check-git-push.sh
@@ -11,8 +11,9 @@ fi
 # Check if the command starts with or contains "git push" as an actual command
 # (not just in a string/message). Look for git push at the start or after && ; |
 if echo "$command" | grep -qE '(^|&&|\|\||;)\s*git push'; then
-  # Check if a review approval exists
-  approval_file="$CLAUDE_PROJECT_DIR/.redpen/signals/push-approved"
+  # Check if a review approval exists — use git toplevel so this works in worktrees too
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "$CLAUDE_PROJECT_DIR")
+  approval_file="$repo_root/.redpen/signals/push-approved"
   if [ -f "$approval_file" ]; then
     # Consume the approval (one-time use)
     rm -f "$approval_file"

--- a/plugin/skills/review-code/SKILL.md
+++ b/plugin/skills/review-code/SKILL.md
@@ -28,7 +28,8 @@ Open all changed code files in the Red Pen desktop app for human review, typical
 3. **Parse and act on the verdict:**
    - **approved** — create the push approval signal so the pre-push hook allows the next push:
      ```bash
-     mkdir -p .redpen/signals && echo "approved" > .redpen/signals/push-approved
+     repo_root=$(git rev-parse --show-toplevel)
+     mkdir -p "$repo_root/.redpen/signals" && echo "approved" > "$repo_root/.redpen/signals/push-approved"
      ```
      Report approval. Code is ready to push.
    - **changes_requested** — for each file's annotations, read the `body` as reviewer feedback on that specific line (`anchor.range.startLine`, `anchor.lineContent`). Implement the requested changes and reply to each annotation with `redpen annotate <file> --body "Done — <summary>" --reply-to <annotation-id>`. Commit the fixes. Only ask clarifying questions if feedback is genuinely unclear.


### PR DESCRIPTION
## Summary

- Uses `git rev-parse --show-toplevel` instead of `$CLAUDE_PROJECT_DIR` to locate the push-approved signal file in `check-git-push.sh`
- Updates the `review-code` skill to write the signal using the same git-toplevel path
- Ensures the hook and skill agree on the signal location regardless of whether work happens in the main repo or a worktree

Closes #17

## Test plan

- [ ] In the main repo: run `/review-code`, approve, then `git push` — should succeed
- [ ] In a worktree: run `/review-code`, approve, then `git push` — should now succeed (was blocked before)
- [ ] Verify signal file is consumed (deleted) after a successful push

🤖 Generated with [Claude Code](https://claude.com/claude-code)