### PR TITLE
feat: automate changelog generation with git-cliff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to Red Pen will be documented in this file.
+
+This changelog is automatically generated from commit history using [git-cliff](https://git-cliff.org).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -94,6 +94,24 @@ tasks:
       - bun run tauri build
       - task: sign
 
+  changelog:
+    desc: Generate changelog for the latest tag
+    cmds:
+      - git cliff --latest --strip header -o CHANGELOG.md
+    preconditions:
+      - sh: command -v git-cliff
+        msg: "git-cliff not installed. Run: cargo install git-cliff"
+
+  changelog:preview:
+    desc: Preview changelog for unreleased changes
+    cmds:
+      - git cliff --unreleased --strip header
+
+  changelog:full:
+    desc: Generate full changelog from all tags
+    cmds:
+      - git cliff -o CHANGELOG.md
+
   release:upload:
     desc: "Upload the signed DMG and CLI binary to the GitHub release"
     cmds:
@@ -163,8 +181,11 @@ tasks:
           sed -i '' "s/^version = \".*\"/version = \"${NEW}\"/" "$f"
         done
 
+        # Generate changelog
+        git cliff --latest --strip header -o CHANGELOG.md
+
         # Commit, tag, push
-        git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml crates/redpen-cli/Cargo.toml crates/redpen-core/Cargo.toml
+        git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml crates/redpen-cli/Cargo.toml crates/redpen-core/Cargo.toml CHANGELOG.md
         git commit -m "release: v${NEW}"
         git tag "v${NEW}"
         git push origin main

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,45 @@
+# cliff.toml — git-cliff changelog generator config
+
+[changelog]
+header = """
+# Changelog\n
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}\
+            {% if commit.body %}\n{{ commit.body | indent(prefix="  ") }}{% endif %}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore|^ci", group = "Miscellaneous" },
+    { message = "^release", skip = true },
+    { body = ".*security", group = "Security" },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "oldest"


### PR DESCRIPTION
Closes #32

- Add `cliff.toml` with conventional commit parsing and grouping
- Add `changelog`, `changelog:preview`, `changelog:full` tasks to Taskfile
- Integrate changelog generation into release task
- Add placeholder CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)