### PR TITLE
feat: migrate push-approved check from file-based to server-based

### DIFF
--- a/crates/redpen-server/src/lib.rs
+++ b/crates/redpen-server/src/lib.rs
@@ -99,6 +99,17 @@ pub struct ReviewPrRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct PushCheckRequest {
+    #[allow(dead_code)]
+    pub repo_root: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PushCheckResponse {
+    pub approved: bool,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct SessionAnnotationsRequest {
     pub session_id: String,
 }
@@ -192,6 +203,11 @@ impl ReviewSessions {
             .entry(session_id.to_string())
             .or_default()
             .push(file);
+    }
+
+    /// Get all tracked session IDs.
+    pub async fn session_ids(&self) -> Vec<String> {
+        self.session_files.lock().await.keys().cloned().collect()
     }
 
     /// Get all files associated with a session.
@@ -436,6 +452,24 @@ async fn rpc_review_pr(
     }
 }
 
+/// Check whether any session has an "approved" verdict (used by the git push hook).
+async fn rpc_push_check(
+    AxumState(state): AxumState<ServerState>,
+    Json(_req): Json<PushCheckRequest>,
+) -> impl IntoResponse {
+    // Check all tracked sessions for a recent approval via the persisted state.
+    let ids = state.sessions.session_ids().await;
+    for session_id in &ids {
+        if let Ok(Some(status)) = state.bridge.review_session_status(session_id) {
+            if status.verdict.as_deref() == Some("approved") {
+                return Json(PushCheckResponse { approved: true });
+            }
+        }
+    }
+
+    Json(PushCheckResponse { approved: false })
+}
+
 // ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
@@ -453,6 +487,7 @@ pub fn build_router(bridge: Arc<dyn AppBridge>, sessions: Arc<ReviewSessions>) -
         .route("/rpc/review", post(rpc_review))
         .route("/rpc/review.pr", post(rpc_review_pr))
         .route("/rpc/session.annotations", post(rpc_session_annotations))
+        .route("/rpc/push.check", post(rpc_push_check))
         .with_state(state)
 }
 

--- a/plugin/hooks/scripts/check-git-push.sh
+++ b/plugin/hooks/scripts/check-git-push.sh
@@ -11,11 +11,21 @@ fi
 # Check if the command starts with or contains "git push" as an actual command
 # (not just in a string/message). Look for git push at the start or after && ; |
 if echo "$command" | grep -qE '(^|&&|\|\||;)\s*git push'; then
-  # Check if a review approval exists — use git toplevel so this works in worktrees too
   repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "$CLAUDE_PROJECT_DIR")
+  port="${REDPEN_PORT:-8789}"
+
+  # Primary: check if the Red Pen server reports push-approved
+  server_response=$(curl -sf --max-time 2 "http://127.0.0.1:${port}/rpc/push.check" \
+    -X POST -H "Content-Type: application/json" \
+    -d "{\"repo_root\": \"$repo_root\"}" 2>/dev/null || echo "")
+
+  if echo "$server_response" | jq -e '.approved == true' >/dev/null 2>&1; then
+    exit 0
+  fi
+
+  # Fallback: legacy file-based signal (for environments where server isn't running)
   approval_file="$repo_root/.redpen/signals/push-approved"
   if [ -f "$approval_file" ]; then
-    # Consume the approval (one-time use)
     rm -f "$approval_file"
     exit 0
   fi

--- a/plugin/skills/review-code/SKILL.md
+++ b/plugin/skills/review-code/SKILL.md
@@ -26,7 +26,7 @@ Open all changed code files in the Red Pen desktop app for human review, typical
    ```
 
 3. **Parse and act on the verdict:**
-   - **approved** — create the push approval signal so the pre-push hook allows the next push:
+   - **approved** — the push approval is automatically tracked by the Red Pen server session. As a fallback for environments where the server isn't running, also create the legacy signal file:
      ```bash
      repo_root=$(git rev-parse --show-toplevel)
      mkdir -p "$repo_root/.redpen/signals" && echo "approved" > "$repo_root/.redpen/signals/push-approved"


### PR DESCRIPTION
Closes #47

Migrates the push-approved signal from a file-based check to querying the Red Pen server.

**Changes:**
- `check-git-push.sh`: Now queries `/rpc/push.check` on the Red Pen server (2s timeout) as primary check. Falls back to legacy file signal when server isn't running.
- `crates/redpen-server/src/lib.rs`: New `/rpc/push.check` endpoint that iterates tracked sessions and checks for an approved verdict via the bridge.
- `plugin/skills/review-code/SKILL.md`: Updated to note server-based approval is primary, file signal is fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)