### PR TITLE
chore: bump version to 0.1.8 for release

### DIFF
--- a/crates/redpen-cli/Cargo.toml
+++ b/crates/redpen-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redpen-cli"
-version = "0.1.6"
+version = "0.1.8"
 edition = "2021"
 
 [[bin]]

--- a/crates/redpen-core/Cargo.toml
+++ b/crates/redpen-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redpen-core"
-version = "0.1.6"
+version = "0.1.8"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "red-pen",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "red-pen-tauri"
-version = "0.1.6"
+version = "0.1.8"
 edition = "2021"
 
 [build-dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicholasVilela/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Red Pen",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "identifier": "com.redpen.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump across all package manifests for the 0.1.8 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated from 0.1.6 to 0.1.8 across all packages and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->