### PR TITLE
feat: gh-fake server, CLI bridge, and resolve-redpen-reviews skill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +319,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +390,28 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -723,6 +776,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1451,6 +1513,22 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -3244,6 +3322,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3801,15 +3889,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
-name = "red-pen-tauri"
-version = "0.1.6"
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
+name = "red-pen-tauri"
+version = "0.2.0"
+dependencies = [
+ "async-trait",
  "chrono",
  "dirs 5.0.1",
  "git2",
  "log",
  "notify",
  "redpen-core",
+ "redpen-gh-fake",
  "redpen-runtime",
  "redpen-server",
  "rusqlite",
@@ -3876,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "redpen-cli"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "clap",
  "dirs 5.0.1",
@@ -3893,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "redpen-core"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "md5",
@@ -3905,6 +4008,23 @@ dependencies = [
  "thiserror 2.0.18",
  "ts-rs",
  "uuid",
+]
+
+[[package]]
+name = "redpen-gh-fake"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "axum-server",
+ "chrono",
+ "rcgen",
+ "reqwest 0.12.28",
+ "rustls",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -3926,6 +4046,7 @@ dependencies = [
  "axum",
  "dirs 5.0.1",
  "redpen-core",
+ "redpen-gh-fake",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -4217,6 +4338,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4224,6 +4346,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4241,6 +4372,7 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5501,6 +5633,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -7019,6 +7152,15 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["src-tauri", "crates/redpen-core", "crates/redpen-cli", "crates/redpen-runtime"]
+members = ["src-tauri", "crates/redpen-core", "crates/redpen-cli", "crates/redpen-runtime", "crates/redpen-gh-fake"]
 resolver = "2"

--- a/crates/redpen-cli/skills/resolve-redpen-reviews/SKILL.md
+++ b/crates/redpen-cli/skills/resolve-redpen-reviews/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: resolve-redpen-reviews
+description: Resolve all PR review comments (human and bot) on the active Redpen review session. Reads comments via the local Redpen server, fixes real issues, dismisses false positives, and posts replies as drafts inside Redpen for the human to publish.
+license: MIT
+allowed-tools: Bash(redpen *) Bash(git add *) Bash(git commit *) Bash(git push *) Bash(git status *) Bash(git diff *) Bash(git log *)
+metadata:
+  scope: redpen
+  semantics: drafts-only
+---
+
+Resolve all review comments on the active Redpen GitHub review session, in two phases: fix everything that's open, then watch for new comments until quiet.
+
+**This skill operates against the Redpen desktop app's local server, not api.github.com.** Replies you post become PendingPublish drafts inside Redpen sidecars; the human reviewer publishes them upstream by clicking "Submit review" in the Redpen UI. You never touch real GitHub.
+
+## Prerequisites
+
+1. **Redpen desktop app must be running.** Run `redpen url` to confirm. If it errors with "redpen server is not running", ask the user to start the desktop app (`cargo tauri dev` or open Redpen normally) and retry.
+2. **A GitHub PR review session must be loaded.** Run `redpen sessions` to list active sessions. If none are loaded, ask the user to open one in Redpen (`redpen review-pr <owner/repo#number>` or via the GitHub Inbox in the app), then retry.
+3. **`agent-reviews` binary on PATH.** The Redpen review loop delegates to it for the comment-management UX. Install with:
+
+    ```bash
+    npm i -g agent-reviews
+    # or, until the GITHUB_API_URL upstream PR merges:
+    npm i -g github:sam-phinizy/agent-reviews#add-github-api-url-env
+    ```
+
+    Or set `REDPEN_REVIEW_BIN=/path/to/agent-reviews` to override.
+
+If multiple sessions are active, this skill operates on the first one returned by `redpen sessions` unless the user specifies a different `--pr <number>` explicitly.
+
+## Phase 1: FETCH & FIX (synchronous)
+
+### Step 1: Pick the active session and fetch comments
+
+Run `redpen sessions --format=json` and pick a target. If exactly one session is active, use its `number`. If multiple, ask the user which.
+
+Then fetch all unanswered comments with full detail:
+
+```bash
+redpen review --pr <number> --unanswered --expanded
+```
+
+`redpen review` is a thin wrapper that execs `agent-reviews` with `GITHUB_API_URL` pointed at the local Redpen server, so the comments come from the active session's sidecars (originally imported from real GitHub when the session was opened). Every comment in the listing is a real review left by a human or bot on the underlying PR.
+
+If zero comments are returned, print "No unanswered comments found" and skip to Phase 2.
+
+### Step 2: Process Each Unanswered Comment
+
+For each comment, evaluate:
+
+#### For Bot Comments (Copilot, CodeRabbit, Cursor, Sourcery, etc.)
+
+Read the referenced code and classify:
+
+1. **TRUE POSITIVE** — A real issue that needs fixing
+2. **FALSE POSITIVE** — Not a real bug (intentional pattern, bot misread, framework-specific)
+3. **UNCERTAIN** — Ask the user
+
+Bots have a high false-positive rate. Verify before fixing.
+
+#### For Human Comments
+
+1. **ACTIONABLE** — Reviewer identified a real issue or requested a concrete change
+2. **DISCUSSION** — Valid point, right approach unclear → ask the user
+3. **ALREADY ADDRESSED** — Concern is no longer relevant
+
+Human reviewers usually have context you don't. When unsure, defer to the author.
+
+#### Act on the Evaluation
+
+- **TRUE POSITIVE / ACTIONABLE** — Fix the code. Track `(comment_id, brief description of fix)`.
+- **FALSE POSITIVE** — Do not change code. Track `(comment_id, reason)`.
+- **DISCUSSION** — Ask the user, apply their decision, track outcome.
+- **ALREADY ADDRESSED** — Track with the explanation.
+- **UNCERTAIN** — Ask the user; if they say skip, track as skipped.
+
+Do NOT reply to comments yet. Replies happen after the commit (Step 4).
+
+### Step 3: Commit and Push
+
+After evaluating and fixing every unanswered comment:
+
+1. Run the project's lint / type-check / tests as appropriate.
+2. Stage, commit, and push:
+
+    ```bash
+    git add -A
+    git commit -m "fix: address PR review findings
+
+    {bullet list of changes, grouped by reviewer or bot}"
+    git push
+    ```
+
+3. Capture the short commit hash from the output.
+
+### Step 4: Reply to Every Processed Comment
+
+Now that the commit hash exists, reply to each comment using `redpen review`. The `--resolve` flag marks the thread resolved inside Redpen; once the human submits the Redpen review, the thread resolution propagates to GitHub along with the replies.
+
+For each TRUE POSITIVE / ACTIONABLE:
+
+```bash
+redpen review --pr <number> --reply <comment_id> "Fixed in {hash}. {brief description}" --resolve
+```
+
+For each FALSE POSITIVE:
+
+```bash
+redpen review --pr <number> --reply <comment_id> "Won't fix: {reason}. {explanation}" --resolve
+```
+
+For DISCUSSION (after user decision):
+
+```bash
+redpen review --pr <number> --reply <comment_id> "{outcome}. {explanation}" --resolve
+```
+
+For ALREADY ADDRESSED:
+
+```bash
+redpen review --pr <number> --reply <comment_id> "Already addressed. {when/how}" --resolve
+```
+
+For SKIPPED:
+
+```bash
+redpen review --pr <number> --reply <comment_id> "Skipped per user request" --resolve
+```
+
+**Drafts-only reminder:** every reply you post lands as a `PendingPublish` annotation in the Redpen sidecar under your bearer-token identity. Nothing is sent to api.github.com until the human reviewer clicks "Submit review" in the Redpen UI. If you change your mind about a reply before the human submits, the user can edit or delete the draft directly in Redpen.
+
+**Do NOT start Phase 2 until all replies are posted.**
+
+## Phase 2: POLL FOR NEW COMMENTS (loop until quiet)
+
+The watcher exits as soon as new comments arrive (after a short grace period to catch batch posts). Run it in a loop until it times out cleanly.
+
+### Step 5: Watcher Loop
+
+Repeat until the watcher reports `WATCH COMPLETE`:
+
+1. Launch the watcher as a background task. Use the native Redpen poller — it has no Node dependency and is the recommended path:
+
+    ```bash
+    redpen watch
+    ```
+
+    Both watchers emit the same exit markers (`EXITING WITH NEW COMMENTS` / `WATCH COMPLETE`) so the rest of this loop is identical either way. `redpen review --pr <number> --watch` (forwards to `agent-reviews --watch`) is also available if you have a reason to use it.
+2. Wait for the watcher to complete.
+3. Read the output:
+    - **`EXITING WITH NEW COMMENTS`**: pull each new comment with `redpen review --pr <number> --detail <id>`, process them as in Phase 1 (Steps 2-4), then go back to step 1.
+    - **`WATCH COMPLETE`**: stop the loop and produce the Summary Report.
+
+Note: new comments here can include comments the human added to Redpen drafts AND new comments imported from GitHub if Redpen re-syncs the PR. Either way, treat them the same.
+
+## Summary Report
+
+```text
+## PR Review Resolution Summary
+
+### Results
+- Fixed: X issues
+- Already addressed: X
+- Won't fix (false positives): X
+- Discussion resolved: X
+- Skipped per user: X
+
+### By Reviewer/Bot
+#### {reviewer or bot}
+- {description} -- Fixed in {commit}
+- {description} -- Won't fix: {reason}
+
+### Status
+All findings addressed. Watch completed.
+Commit: {hash} (drafts in Redpen; awaiting human submit)
+```
+
+## Important Notes
+
+### Drafts-only architecture
+- `redpen review` routes through the local Redpen HTTP server, not api.github.com.
+- Replies are local drafts under your bearer-token identity, not real GitHub comments.
+- The human reviewer publishes by clicking "Submit review" in the Redpen UI.
+- You can fearlessly retry, edit, or discard your work at any point during the loop.
+
+### Response policy
+- Every comment gets a reply. No silent ignores.
+- For bots: replies stop them re-raising the same finding next sync.
+- For humans: replies surface in Redpen and (after submit) on GitHub.
+
+### When uncertain, ask the user
+- Architectural changes
+- Subjective tradeoffs
+- Multiple valid interpretations
+- Fixes with non-obvious side effects
+
+### Best practices
+- Verify findings before fixing — bots have false positives, humans rarely do.
+- Keep fixes minimal and focused; do not refactor unrelated code.
+- Run lint and type-check before committing.
+- Group related fixes into a single commit.
+- Copilot `suggestion` blocks usually contain ready-to-apply fixes.
+- Prefer the human reviewer's specific code suggestion over your own paraphrase unless it introduces issues.

--- a/crates/redpen-cli/src/main.rs
+++ b/crates/redpen-cli/src/main.rs
@@ -113,6 +113,85 @@ enum Commands {
     },
     /// Print agent usage prompt (system prompt for AI agents using redpen)
     Agents,
+    /// Print the base URL of the running redpen-gh-fake HTTP server.
+    Url,
+    /// List active GitHub review sessions (sourced from /redpen/meta).
+    Sessions {
+        /// Output format: "table" (default) or "json"
+        #[arg(long, default_value = "table")]
+        format: String,
+    },
+    /// Run a child process with GITHUB_API_URL set to the local fake-gh server.
+    ///
+    /// Useful for pointing GitHub-aware tools (e.g. agent-reviews via npx)
+    /// at Redpen instead of api.github.com. Use `--` to separate redpen
+    /// flags from the child command:
+    ///
+    ///     redpen run -- agent-reviews --pr 7 --unanswered
+    Run {
+        /// Skip GITHUB_API_URL injection so the child talks to real api.github.com.
+        /// Default is local (Redpen sandboxed). Use this when you want the
+        /// same wrapper but actually hit upstream GitHub.
+        #[arg(long)]
+        remote: bool,
+        /// Command and its arguments.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
+        args: Vec<String>,
+    },
+    /// Convenience alias for `redpen run -- agent-reviews [args...]`.
+    ///
+    /// Override the binary with REDPEN_REVIEW_BIN. Defaults to `agent-reviews`
+    /// (assumed to be on PATH; install with `npm i -g agent-reviews` or
+    /// `npm i -g github:sam-phinizy/agent-reviews#add-github-api-url-env`
+    /// until upstream merges the GITHUB_API_URL env support).
+    Review {
+        /// Skip GITHUB_API_URL injection so agent-reviews talks to real
+        /// api.github.com. Default is local (Redpen sandboxed).
+        #[arg(long)]
+        remote: bool,
+        /// Arguments forwarded to agent-reviews.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Watch the active session for new review comments, exiting when any
+    /// appear (or after a configurable idle timeout). Native implementation
+    /// that hits the local Redpen server directly — no agent-reviews / Node
+    /// dependency.
+    ///
+    /// Output format mirrors `agent-reviews --watch` so the same skill
+    /// prompt drives both. Look for `EXITING WITH NEW COMMENTS` / `WATCH COMPLETE`.
+    Watch {
+        /// PR number to watch. Defaults to the active session's PR if exactly
+        /// one session is loaded.
+        #[arg(long)]
+        pr: Option<u64>,
+        /// `owner/name` of the repo. Defaults to the active session's repo.
+        #[arg(long, value_name = "OWNER/NAME")]
+        repo: Option<String>,
+        /// Seconds of inactivity before exiting cleanly. Default 600 (10m).
+        #[arg(long, default_value_t = 600)]
+        idle_timeout: u64,
+        /// Seconds between polls. Default 30.
+        #[arg(long, default_value_t = 30)]
+        poll_interval: u64,
+        /// Seconds to wait after detecting a new comment, in case more land
+        /// in the same batch. Default 5.
+        #[arg(long, default_value_t = 5)]
+        grace_period: u64,
+    },
+    /// Install Redpen-flavored Claude Code skills into ~/.claude/skills/.
+    ///
+    /// Skill files are embedded in this binary, so no network or repo
+    /// checkout is required. By default writes to the user-global location;
+    /// pass --project to write to ./.claude/skills/ instead.
+    InstallSkills {
+        /// Install into the current directory's .claude/skills/ instead of ~.
+        #[arg(long)]
+        project: bool,
+        /// Overwrite existing files without prompting.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 /// Exit codes for the pre-push review gate.
@@ -188,6 +267,18 @@ fn main() {
             print!("{}", AGENT_PROMPT);
             Ok(())
         }
+        Commands::Url => cmd_url(),
+        Commands::Sessions { format } => cmd_sessions(&format),
+        Commands::Run { remote, args } => cmd_run(remote, args),
+        Commands::Review { remote, args } => cmd_review(remote, args),
+        Commands::InstallSkills { project, force } => cmd_install_skills(project, force),
+        Commands::Watch {
+            pr,
+            repo,
+            idle_timeout,
+            poll_interval,
+            grace_period,
+        } => cmd_watch(pr, repo, idle_timeout, poll_interval, grace_period),
     };
     if let Err(e) = result {
         eprintln!("Error: {}", e);
@@ -978,6 +1069,300 @@ fn cmd_review_pr(
 
     #[allow(unreachable_code)]
     Err("Red Pen app server is not available. Start the app first.".into())
+}
+
+// ---------------------------------------------------------------------------
+// gh-fake bridge commands
+// ---------------------------------------------------------------------------
+
+fn require_server_url() -> Result<String, Box<dyn std::error::Error>> {
+    server_client::server_url().ok_or_else(|| {
+        "redpen server is not running. Start the desktop app or `cargo tauri dev`.".into()
+    })
+}
+
+fn cmd_url() -> Result<(), Box<dyn std::error::Error>> {
+    println!("{}", require_server_url()?);
+    Ok(())
+}
+
+fn cmd_sessions(format: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let url = require_server_url()?;
+    let body: serde_json::Value = ureq::get(&format!("{}/redpen/meta", url))
+        .call()?
+        .body_mut()
+        .read_json()?;
+    let sessions = body["active_sessions"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(&sessions)?),
+        _ => {
+            if sessions.is_empty() {
+                println!("No active GitHub review sessions.");
+                return Ok(());
+            }
+            println!(
+                "{:<12} {:<32} {:<8} {}",
+                "ID", "REPO", "PR", "BRANCH"
+            );
+            for s in &sessions {
+                let id = s["id"].as_str().unwrap_or("");
+                let owner = s["owner"].as_str().unwrap_or("");
+                let repo = s["repo"].as_str().unwrap_or("");
+                let number = s["number"].as_u64().unwrap_or(0);
+                let branch = s["branch"].as_str().unwrap_or("");
+                println!(
+                    "{:<12} {:<32} #{:<7} {}",
+                    truncate(id, 12),
+                    format!("{}/{}", owner, repo),
+                    number,
+                    branch
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max.saturating_sub(1)])
+    }
+}
+
+fn run_with_env(
+    cmd: &str,
+    args: &[String],
+    remote: bool,
+    on_not_found: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut command = std::process::Command::new(cmd);
+    command.args(args);
+    if !remote {
+        // Default: route through the local Redpen server (sandboxed).
+        let url = require_server_url()?;
+        command.env("GITHUB_API_URL", &url);
+        command.env("REDPEN_BASE_URL", &url);
+
+        // If there is exactly one active GH review session, surface its
+        // identity through env so consumers (e.g. agent-reviews) don't have
+        // to be told the repo + PR explicitly. Multi-session is intentionally
+        // not auto-resolved — too much footgun risk.
+        if let Some((repo, pr, branch)) = solo_session_identity() {
+            command.env("GH_REPO", &repo);
+            command.env("REDPEN_PR", pr.to_string());
+            command.env("REDPEN_BRANCH", &branch);
+        }
+    }
+    // In --remote mode, leave the child's env untouched so it talks to real
+    // api.github.com using whatever auth/proxy setup the user already has.
+    let result = command.status();
+    match result {
+        Ok(status) => process::exit(status.code().unwrap_or(1)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(on_not_found.into()),
+        Err(e) => Err(e.to_string().into()),
+    }
+}
+
+/// Returns (owner/repo, pr_number, branch) iff exactly one GH session is
+/// active. Returns None on zero or multiple sessions, or any fetch error —
+/// caller falls back to no-injection.
+fn solo_session_identity() -> Option<(String, u64, String)> {
+    let url = server_client::server_url()?;
+    let body: serde_json::Value = ureq::get(&format!("{}/redpen/meta", url))
+        .call()
+        .ok()?
+        .body_mut()
+        .read_json()
+        .ok()?;
+    let sessions = body["active_sessions"].as_array()?;
+    if sessions.len() != 1 {
+        return None;
+    }
+    let s = &sessions[0];
+    let owner = s["owner"].as_str()?;
+    let repo = s["repo"].as_str()?;
+    let number = s["number"].as_u64()?;
+    let branch = s["branch"].as_str().unwrap_or("");
+    Some((format!("{}/{}", owner, repo), number, branch.to_string()))
+}
+
+fn cmd_run(remote: bool, args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let (cmd, rest) = args
+        .split_first()
+        .ok_or("expected a command after `--`")?;
+    let hint = format!("command not found: {} (is it on PATH?)", cmd);
+    run_with_env(cmd, rest, remote, &hint)
+}
+
+fn cmd_review(remote: bool, args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let bin = std::env::var("REDPEN_REVIEW_BIN").unwrap_or_else(|_| "agent-reviews".into());
+    let hint = format!(
+        "`{}` not found on PATH. Install with one of:\n\
+         \n  npm i -g agent-reviews\n\
+         \n  npm i -g github:sam-phinizy/agent-reviews#add-github-api-url-env  \
+         (until upstream merges)\n\
+         \nOr override the binary: REDPEN_REVIEW_BIN=/path/to/agent-reviews redpen review ...",
+        bin
+    );
+    run_with_env(&bin, &args, remote, &hint)
+}
+
+// ---------------------------------------------------------------------------
+// Watch (native polling)
+// ---------------------------------------------------------------------------
+
+fn cmd_watch(
+    pr_arg: Option<u64>,
+    repo_arg: Option<String>,
+    idle_timeout: u64,
+    poll_interval: u64,
+    grace_period: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let url = require_server_url()?;
+
+    // Resolve target session.
+    let (repo, pr) = match (repo_arg, pr_arg) {
+        (Some(r), Some(n)) => (r, n),
+        _ => {
+            let solo = solo_session_identity()
+                .ok_or("no PR specified and there isn't exactly one active session — pass --pr <n> [--repo owner/name]")?;
+            (solo.0, solo.1)
+        }
+    };
+
+    let comments_url = format!("{}/repos/{}/pulls/{}/comments", url, repo, pr);
+    let started = std::time::Instant::now();
+    println!("=== Redpen Watch Mode ===");
+    println!("PR: {}#{}", repo, pr);
+    println!(
+        "Polling every {}s, exit after {}s of inactivity.",
+        poll_interval, idle_timeout
+    );
+
+    let initial_ids = fetch_comment_ids(&comments_url)?;
+    println!("Initial state: {} comments tracked", initial_ids.len());
+
+    let last_change = std::time::Instant::now();
+    let mut seen: std::collections::HashSet<i64> = initial_ids.into_iter().collect();
+    let mut poll = 0usize;
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(poll_interval));
+        poll += 1;
+        let elapsed = started.elapsed().as_secs();
+        let idle = last_change.elapsed().as_secs();
+
+        let current = match fetch_comment_ids(&comments_url) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("[poll #{poll} t={elapsed}s] fetch error: {e} — retrying next poll");
+                continue;
+            }
+        };
+        let new_ids: Vec<i64> = current.iter().copied().filter(|id| !seen.contains(id)).collect();
+
+        if !new_ids.is_empty() {
+            // Grace period in case a batch is mid-publish.
+            std::thread::sleep(std::time::Duration::from_secs(grace_period));
+            let after = fetch_comment_ids(&comments_url).unwrap_or(current);
+            let final_new: Vec<i64> = after
+                .iter()
+                .copied()
+                .filter(|id| !seen.contains(id))
+                .collect();
+            for id in &final_new {
+                seen.insert(*id);
+            }
+            println!(
+                "[poll #{poll} t={elapsed}s] new comments: {}",
+                final_new
+                    .iter()
+                    .map(i64::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            println!("EXITING WITH NEW COMMENTS");
+            return Ok(());
+        }
+
+        if idle >= idle_timeout {
+            println!("[poll #{poll} t={elapsed}s idle={idle}s] no new comments");
+            println!("WATCH COMPLETE");
+            return Ok(());
+        }
+
+        println!(
+            "[poll #{poll} t={elapsed}s idle={idle}s] no new comments ({}/{}s)",
+            idle, idle_timeout
+        );
+    }
+}
+
+fn fetch_comment_ids(url: &str) -> Result<Vec<i64>, Box<dyn std::error::Error>> {
+    let body: serde_json::Value = ureq::get(url).call()?.body_mut().read_json()?;
+    let arr = body.as_array().ok_or("expected JSON array")?;
+    Ok(arr
+        .iter()
+        .filter_map(|c| c["id"].as_i64())
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Skill installer
+// ---------------------------------------------------------------------------
+
+/// Bundled skills, each as `(skill_name, SKILL.md content)`. Add new entries
+/// here to ship more skills with the binary.
+const BUNDLED_SKILLS: &[(&str, &str)] = &[(
+    "resolve-redpen-reviews",
+    include_str!("../skills/resolve-redpen-reviews/SKILL.md"),
+)];
+
+fn cmd_install_skills(project: bool, force: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let target_root = if project {
+        std::env::current_dir()?.join(".claude").join("skills")
+    } else {
+        dirs::home_dir()
+            .ok_or("could not resolve home directory")?
+            .join(".claude")
+            .join("skills")
+    };
+
+    let mut written = 0usize;
+    let mut skipped = 0usize;
+    for (name, content) in BUNDLED_SKILLS {
+        let dir = target_root.join(name);
+        let path = dir.join("SKILL.md");
+        std::fs::create_dir_all(&dir)?;
+        if path.exists() && !force {
+            eprintln!("skip (exists): {}", path.display());
+            skipped += 1;
+            continue;
+        }
+        std::fs::write(&path, content)?;
+        eprintln!("wrote: {}", path.display());
+        written += 1;
+    }
+
+    if skipped > 0 && written == 0 {
+        eprintln!(
+            "\nAll skills already installed. Re-run with --force to overwrite."
+        );
+    } else {
+        eprintln!(
+            "\nInstalled {} skill(s) into {}.",
+            written,
+            target_root.display()
+        );
+        if !project {
+            eprintln!("Use them in Claude Code via `/resolve-redpen-reviews`.");
+        }
+    }
+    Ok(())
 }
 
 fn review_output(

--- a/crates/redpen-cli/src/server_client.rs
+++ b/crates/redpen-cli/src/server_client.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 
 /// Read the server port from ~/.config/redpen/server.json.
 /// Returns None if the file doesn't exist or the server process is dead.
-fn server_url() -> Option<String> {
+pub fn server_url() -> Option<String> {
     let path = redpen_server::discovery_path();
     let content = std::fs::read_to_string(&path).ok()?;
     let info: serde_json::Value = serde_json::from_str(&content).ok()?;

--- a/crates/redpen-gh-fake/Cargo.toml
+++ b/crates/redpen-gh-fake/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "redpen-gh-fake"
+version = "0.1.0"
+edition = "2021"
+description = "Localhost GitHub-API-compatible HTTP server backed by a pluggable trait. Lets agent tools (e.g. agent-reviews) target Redpen sessions instead of api.github.com."
+
+[dependencies]
+axum = "0.8"
+tokio = { version = "1", features = ["sync", "net", "rt", "macros", "time"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+async-trait = "0.1"
+thiserror = "2"
+
+[dev-dependencies]
+reqwest = { version = "0.12", features = ["json"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "net", "process", "fs", "io-util"] }
+serde_json = "1"
+axum-server = { version = "0.7", features = ["tls-rustls"] }
+rcgen = "0.13"
+rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/crates/redpen-gh-fake/examples/seed_review.rs
+++ b/crates/redpen-gh-fake/examples/seed_review.rs
@@ -1,0 +1,81 @@
+//! Read review findings as JSON from stdin and POST them to a running
+//! redpen-gh-fake server as top-level review comments.
+//!
+//! Input shape (one of):
+//!   * `[{"path": "src/foo.rs", "line": 25, "body": "..."}, ...]`
+//!   * `{"comments": [...]}`
+//!
+//! Required env: `BASE_URL` (e.g. http://127.0.0.1:55555), `OWNER`, `REPO`, `PR`.
+//! Optional env: `REVIEWER_TOKEN` (default "codex-review") — surfaces as the
+//! comment's `user.login`.
+//!
+//!     cat findings.json | cargo run --example seed_review
+
+use std::io::Read;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let base = std::env::var("BASE_URL").expect("BASE_URL");
+    let owner = std::env::var("OWNER").expect("OWNER");
+    let repo = std::env::var("REPO").expect("REPO");
+    let pr: u64 = std::env::var("PR")
+        .expect("PR")
+        .parse()
+        .expect("PR must be numeric");
+    let token = std::env::var("REVIEWER_TOKEN").unwrap_or_else(|_| "codex-review".into());
+
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf).expect("stdin");
+    let parsed: serde_json::Value = serde_json::from_str(&buf).expect("input must be JSON");
+    let findings = match &parsed {
+        serde_json::Value::Array(arr) => arr.clone(),
+        serde_json::Value::Object(obj) => obj
+            .get("comments")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+
+    let client = reqwest::Client::new();
+    let mut posted = 0usize;
+    for f in &findings {
+        let path = f.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let line = f.get("line").and_then(|v| v.as_u64()).unwrap_or(1);
+        let body = f.get("body").and_then(|v| v.as_str()).unwrap_or("");
+        if path.is_empty() || body.is_empty() {
+            eprintln!("skipping malformed finding: {f}");
+            continue;
+        }
+
+        let url = format!("{}/repos/{}/{}/pulls/{}/comments", base, owner, repo, pr);
+        let resp = client
+            .post(&url)
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "path": path,
+                "line": line,
+                "body": body,
+                "side": "RIGHT",
+            }))
+            .send()
+            .await
+            .expect("POST");
+        if !resp.status().is_success() {
+            eprintln!(
+                "failed: {} {} (POST {})",
+                resp.status(),
+                resp.text().await.unwrap_or_default(),
+                url
+            );
+            continue;
+        }
+        let created: serde_json::Value = resp.json().await.expect("response json");
+        println!(
+            "  + {}:{} (id={}, author={})",
+            path, line, created["id"], created["user"]["login"]
+        );
+        posted += 1;
+    }
+    eprintln!("posted {posted}/{} finding(s)", findings.len());
+}

--- a/crates/redpen-gh-fake/examples/serve_seeded.rs
+++ b/crates/redpen-gh-fake/examples/serve_seeded.rs
@@ -1,0 +1,52 @@
+//! Spin up a server pre-seeded with a fixed session + comment.
+//!
+//! Used by cross-language client tests and for manual probing.
+//!
+//!     cargo run -p redpen-gh-fake --example serve_seeded -- 0
+//!
+//! Prints `LISTENING=127.0.0.1:<port>` to stdout, then serves indefinitely.
+
+use std::sync::Arc;
+
+use redpen_gh_fake::{test_backend::TestBackend, SessionRef};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let port: u16 = std::env::args()
+        .nth(1)
+        .as_deref()
+        .unwrap_or("0")
+        .parse()
+        .expect("port");
+
+    let backend = TestBackend::new();
+    let session = SessionRef {
+        id: "session-1".into(),
+        owner: "octocat".into(),
+        repo: "hello".into(),
+        number: 42,
+        title: "Add greeting".into(),
+        body: "Adds a hello message.".into(),
+        head_ref: "feature/hello".into(),
+        head_sha: "deadbeef".into(),
+        base_ref: "main".into(),
+        base_sha: "cafebabe".into(),
+        author_login: "octocat".into(),
+        viewer_login: "reviewer".into(),
+        html_url: "redpen://session/session-1".into(),
+    };
+    backend.add_session(session);
+    if std::env::var("REDPEN_SKIP_SEED_COMMENT").is_err() {
+        let seeded =
+            backend.seed_comment("session-1", "src/foo.rs", 10, "nit: rename this", "alice");
+        eprintln!("seeded comment database_id={}", seeded.database_id);
+    } else {
+        eprintln!("REDPEN_SKIP_SEED_COMMENT set; starting with no comments");
+    }
+
+    let (addr, handle) = redpen_gh_fake::bind(Arc::new(backend), port)
+        .await
+        .expect("bind");
+    println!("LISTENING={}", addr);
+    handle.await.unwrap();
+}

--- a/crates/redpen-gh-fake/src/backend.rs
+++ b/crates/redpen-gh-fake/src/backend.rs
@@ -1,0 +1,110 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, thiserror::Error)]
+pub enum BackendError {
+    #[error("not found")]
+    NotFound,
+    #[error("conflict: {0}")]
+    Conflict(String),
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+// thiserror is the only extra dep; pull it in via Cargo.toml on first compile.
+// Inlining a small impl here would also work, but thiserror keeps it tidy.
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionRef {
+    pub id: String,
+    pub owner: String,
+    pub repo: String,
+    pub number: u64,
+    pub title: String,
+    pub body: String,
+    pub head_ref: String,
+    pub head_sha: String,
+    pub base_ref: String,
+    pub base_sha: String,
+    pub author_login: String,
+    pub viewer_login: String,
+    pub html_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewComment {
+    pub database_id: i64,
+    pub node_id: String,
+    pub thread_id: String,
+    pub path: String,
+    pub line: u32,
+    pub diff_hunk: String,
+    pub body: String,
+    pub author: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub in_reply_to_database_id: Option<i64>,
+    pub html_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreadRef {
+    pub node_id: String,
+    pub is_resolved: bool,
+    pub root_database_id: i64,
+}
+
+#[async_trait]
+pub trait GhBackend: Send + Sync + 'static {
+    async fn find_session_for_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+    ) -> Option<SessionRef>;
+
+    async fn find_session_for_pr(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+    ) -> Option<SessionRef>;
+
+    /// All active GitHub sessions. Used by the `/redpen/meta` self-describing
+    /// endpoint so agents/skills can discover which PRs they may operate on
+    /// without needing the user to pass flags.
+    async fn list_active_sessions(&self) -> Vec<SessionRef>;
+
+    async fn list_review_comments(&self, session_id: &str) -> Vec<ReviewComment>;
+
+    async fn list_threads(&self, session_id: &str) -> Vec<ThreadRef>;
+
+    /// Create a new top-level review comment (a "thread root"). Used by
+    /// reviewer bots to seed review findings against an active session
+    /// without going to api.github.com. Mirrors GitHub's
+    /// `POST /repos/{owner}/{repo}/pulls/{n}/comments` endpoint.
+    async fn append_review_comment(
+        &self,
+        session_id: &str,
+        agent: &str,
+        path: &str,
+        line: u32,
+        body: &str,
+    ) -> Result<ReviewComment, BackendError>;
+
+    async fn append_reply(
+        &self,
+        session_id: &str,
+        parent_database_id: i64,
+        agent: &str,
+        body: &str,
+    ) -> Result<ReviewComment, BackendError>;
+
+    async fn set_thread_resolved(
+        &self,
+        session_id: &str,
+        thread_node_id: &str,
+        resolved: bool,
+    ) -> Result<ThreadRef, BackendError>;
+}

--- a/crates/redpen-gh-fake/src/graphql.rs
+++ b/crates/redpen-gh-fake/src/graphql.rs
@@ -1,0 +1,104 @@
+//! Minimal GraphQL endpoint covering the two operations agent-reviews uses:
+//! find a review thread by comment id, and resolve a review thread.
+
+use axum::{extract::State, http::StatusCode, Json};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::ServerState;
+
+#[derive(Deserialize)]
+pub(crate) struct Body {
+    query: String,
+    #[serde(default)]
+    variables: Value,
+}
+
+pub(crate) async fn handle(
+    State(s): State<ServerState>,
+    Json(body): Json<Body>,
+) -> Result<Json<Value>, StatusCode> {
+    if body.query.contains("resolveReviewThread") {
+        return resolve_thread(s, body.variables).await;
+    }
+    if body.query.contains("reviewThreads") {
+        return find_thread(s, body.variables).await;
+    }
+    // Unsupported query — return a GraphQL-shaped error so callers can see why.
+    Ok(Json(json!({
+        "errors": [{ "message": "redpen-gh-fake: unsupported GraphQL query" }],
+    })))
+}
+
+async fn find_thread(s: ServerState, vars: Value) -> Result<Json<Value>, StatusCode> {
+    let owner = vars.get("owner").and_then(Value::as_str).unwrap_or_default();
+    let repo = vars.get("repo").and_then(Value::as_str).unwrap_or_default();
+    let pr = vars
+        .get("pr")
+        .and_then(Value::as_u64)
+        .ok_or(StatusCode::UNPROCESSABLE_ENTITY)?;
+
+    let Some(session) = s.backend.find_session_for_pr(owner, repo, pr).await else {
+        // Mirror GitHub's shape: return null pullRequest, no errors.
+        return Ok(Json(json!({
+            "data": { "repository": { "pullRequest": null } }
+        })));
+    };
+
+    let threads = s.backend.list_threads(&session.id).await;
+    let nodes: Vec<Value> = threads
+        .iter()
+        .map(|t| {
+            json!({
+                "id": t.node_id,
+                "isResolved": t.is_resolved,
+                "comments": {
+                    "nodes": [{ "databaseId": t.root_database_id }]
+                }
+            })
+        })
+        .collect();
+
+    // Single-page response — agent-reviews stops paginating when hasNextPage=false.
+    Ok(Json(json!({
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": nodes,
+                    }
+                }
+            }
+        }
+    })))
+}
+
+async fn resolve_thread(s: ServerState, vars: Value) -> Result<Json<Value>, StatusCode> {
+    let thread_id = vars
+        .get("threadId")
+        .and_then(Value::as_str)
+        .ok_or(StatusCode::UNPROCESSABLE_ENTITY)?;
+
+    // We don't get owner/repo/pr in the mutation variables — the thread id
+    // alone is the key. The backend has to be able to resolve threads
+    // globally by their synthetic node id.
+    //
+    // Iterate sessions? For v1 the session is implicit: backend.set_thread_resolved
+    // accepts the thread node id and finds the owning session itself.
+    match s.backend.set_thread_resolved("", thread_id, true).await {
+        Ok(updated) => Ok(Json(json!({
+            "data": {
+                "resolveReviewThread": {
+                    "thread": { "id": updated.node_id, "isResolved": updated.is_resolved }
+                }
+            }
+        }))),
+        Err(crate::backend::BackendError::NotFound) => Ok(Json(json!({
+            "errors": [{ "message": "thread not found" }]
+        }))),
+        Err(e) => Ok(Json(json!({
+            "errors": [{ "message": e.to_string() }]
+        }))),
+    }
+}

--- a/crates/redpen-gh-fake/src/lib.rs
+++ b/crates/redpen-gh-fake/src/lib.rs
@@ -1,0 +1,82 @@
+//! Localhost GitHub-API-compatible HTTP server.
+//!
+//! Speaks enough of GitHub's REST + GraphQL surface that agent tools written
+//! against `api.github.com` (e.g. `pbakaus/agent-reviews`) can run against
+//! a Redpen session instead.
+//!
+//! The server is backed by a pluggable `GhBackend` trait so it can be
+//! integration-tested without Tauri, SQLite, or sidecar I/O.
+
+use std::sync::Arc;
+
+use axum::{
+    routing::{get, post},
+    Router,
+};
+
+mod backend;
+mod graphql;
+mod meta;
+mod rest;
+mod shapes;
+
+pub use backend::{BackendError, GhBackend, ReviewComment, SessionRef, ThreadRef};
+pub mod test_backend;
+
+#[derive(Clone)]
+pub(crate) struct ServerState {
+    pub backend: Arc<dyn GhBackend>,
+}
+
+/// Build the router.
+///
+/// Routes are mounted under both `/` (for clients hitting raw `api.github.com`
+/// paths, e.g. `agent-reviews` with `GITHUB_API_URL=http://host:port`) and
+/// `/api/v3` (for GHE-style clients like `gh` with `GH_HOST=host:port`).
+pub fn router(backend: Arc<dyn GhBackend>) -> Router {
+    let state = ServerState { backend };
+
+    let routes = Router::new()
+        .route("/repos/{owner}/{repo}/pulls", get(rest::list_pulls))
+        .route(
+            "/repos/{owner}/{repo}/pulls/{number}/comments",
+            get(rest::list_review_comments).post(rest::create_review_comment),
+        )
+        .route(
+            "/repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies",
+            post(rest::reply_to_comment),
+        )
+        .route(
+            "/repos/{owner}/{repo}/issues/{number}/comments",
+            get(rest::list_issue_comments).post(rest::create_issue_comment),
+        )
+        .route(
+            "/repos/{owner}/{repo}/pulls/{number}/reviews",
+            get(rest::list_reviews),
+        )
+        .route("/graphql", post(graphql::handle));
+
+    Router::new()
+        .merge(routes.clone())
+        .nest("/api/v3", routes)
+        // Redpen-specific self-description — NOT mounted under /api/v3 because
+        // it's not a GitHub API surface. Agents/skills probe this to discover
+        // active sessions and confirm they're sandboxed.
+        .route("/redpen/meta", get(meta::handle))
+        .with_state(state)
+}
+
+/// Convenience: bind on `127.0.0.1:port` (0 for ephemeral) and return the
+/// bound address + a future that drives the server.
+pub async fn bind(
+    backend: Arc<dyn GhBackend>,
+    port: u16,
+) -> std::io::Result<(std::net::SocketAddr, tokio::task::JoinHandle<()>)> {
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", port)).await?;
+    let addr = listener.local_addr()?;
+    let app = router(backend);
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    Ok((addr, handle))
+}

--- a/crates/redpen-gh-fake/src/meta.rs
+++ b/crates/redpen-gh-fake/src/meta.rs
@@ -1,0 +1,74 @@
+//! Self-describing endpoint at `/redpen/meta`.
+//!
+//! Lets agents/skills probe whether they're talking to a real GitHub or to
+//! Redpen, what semantics apply (drafts vs publish), and which sessions are
+//! available — without the user having to pass any flags.
+
+use axum::{extract::State, Json};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::ServerState;
+
+#[derive(Serialize)]
+struct MetaResponse {
+    server: &'static str,
+    version: &'static str,
+    /// `drafts-only` — writes (replies, thread resolution) land in local
+    /// sidecars and do not propagate to api.github.com until the human
+    /// hits "Submit review" in the Redpen UI.
+    semantics: &'static str,
+    /// REST and GraphQL paths that are wired up. Anything else 404s.
+    supported: SupportedSurface,
+    /// PRs the agent may operate on. Empty if nothing is loaded in Redpen.
+    active_sessions: Vec<Value>,
+}
+
+#[derive(Serialize)]
+struct SupportedSurface {
+    rest: &'static [&'static str],
+    graphql: &'static [&'static str],
+}
+
+const REST_PATHS: &[&str] = &[
+    "GET /repos/{owner}/{repo}/pulls",
+    "GET /repos/{owner}/{repo}/pulls/{n}/comments",
+    "POST /repos/{owner}/{repo}/pulls/{n}/comments/{id}/replies",
+    "GET/POST /repos/{owner}/{repo}/issues/{n}/comments",
+    "GET /repos/{owner}/{repo}/pulls/{n}/reviews",
+];
+
+const GRAPHQL_OPS: &[&str] = &[
+    "query reviewThreads",
+    "mutation resolveReviewThread",
+];
+
+pub(crate) async fn handle(State(s): State<ServerState>) -> Json<Value> {
+    let active = s.backend.list_active_sessions().await;
+    let active_json: Vec<Value> = active
+        .iter()
+        .map(|s| {
+            json!({
+                "id": s.id,
+                "owner": s.owner,
+                "repo": s.repo,
+                "number": s.number,
+                "branch": s.head_ref,
+                "title": s.title,
+                "html_url": s.html_url,
+            })
+        })
+        .collect();
+
+    let resp = MetaResponse {
+        server: "redpen-gh-fake",
+        version: env!("CARGO_PKG_VERSION"),
+        semantics: "drafts-only",
+        supported: SupportedSurface {
+            rest: REST_PATHS,
+            graphql: GRAPHQL_OPS,
+        },
+        active_sessions: active_json,
+    };
+    Json(serde_json::to_value(resp).unwrap())
+}

--- a/crates/redpen-gh-fake/src/rest.rs
+++ b/crates/redpen-gh-fake/src/rest.rs
@@ -1,0 +1,183 @@
+//! REST handlers covering the surface used by `pbakaus/agent-reviews`.
+
+use std::collections::HashMap;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    Json,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::shapes::{pr_json, review_comment_json};
+use crate::ServerState;
+
+#[derive(Deserialize)]
+pub(crate) struct PullsQuery {
+    head: Option<String>,
+    state: Option<String>,
+}
+
+/// `GET /repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=open`
+pub(crate) async fn list_pulls(
+    State(s): State<ServerState>,
+    Path((owner, repo)): Path<(String, String)>,
+    Query(q): Query<PullsQuery>,
+) -> Json<Vec<Value>> {
+    if q.state.as_deref().unwrap_or("open") != "open" {
+        return Json(vec![]);
+    }
+    let Some(head) = q.head else {
+        return Json(vec![]);
+    };
+    // head is "owner:branch" — strip the owner prefix.
+    let branch = head.split_once(':').map(|(_, b)| b).unwrap_or(&head);
+    match s.backend.find_session_for_branch(&owner, &repo, branch).await {
+        Some(session) => Json(vec![pr_json(&session)]),
+        None => Json(vec![]),
+    }
+}
+
+/// `GET /repos/{owner}/{repo}/pulls/{number}/comments`
+pub(crate) async fn list_review_comments(
+    State(s): State<ServerState>,
+    Path((owner, repo, number)): Path<(String, String, u64)>,
+) -> Result<Json<Vec<Value>>, StatusCode> {
+    let session = s
+        .backend
+        .find_session_for_pr(&owner, &repo, number)
+        .await
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let comments = s.backend.list_review_comments(&session.id).await;
+    Ok(Json(comments.iter().map(review_comment_json).collect()))
+}
+
+/// `GET /repos/{owner}/{repo}/issues/{number}/comments`
+///
+/// Returns `[]` v1 — Redpen has no issue-level comment concept.
+pub(crate) async fn list_issue_comments(
+    State(_s): State<ServerState>,
+    Path((_owner, _repo, _number)): Path<(String, String, u64)>,
+) -> Json<Vec<Value>> {
+    Json(vec![])
+}
+
+/// `POST /repos/{owner}/{repo}/issues/{number}/comments`
+///
+/// Defensive: agent-reviews falls back here if a threaded reply 404s.
+/// We never 404, so this is a no-op echo.
+pub(crate) async fn create_issue_comment(
+    State(_s): State<ServerState>,
+    Path((_owner, _repo, _number)): Path<(String, String, u64)>,
+    headers: HeaderMap,
+    Json(body): Json<HashMap<String, Value>>,
+) -> Json<Value> {
+    let agent = bearer_identity(&headers);
+    let body_text = body
+        .get("body")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    Json(json!({
+        "id": chrono::Utc::now().timestamp_micros(),
+        "user": { "login": agent },
+        "body": body_text,
+        "html_url": "redpen://issue-comment-noop",
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "updated_at": chrono::Utc::now().to_rfc3339(),
+    }))
+}
+
+/// `GET /repos/{owner}/{repo}/pulls/{number}/reviews`
+///
+/// Returns `[]` v1 — Redpen import doesn't currently capture review-summary
+/// bodies (only individual review threads).
+pub(crate) async fn list_reviews(
+    State(_s): State<ServerState>,
+    Path((_owner, _repo, _number)): Path<(String, String, u64)>,
+) -> Json<Vec<Value>> {
+    Json(vec![])
+}
+
+/// `POST /repos/{owner}/{repo}/pulls/{number}/comments`
+///
+/// Create a new top-level review comment. Used by reviewer bots to seed
+/// findings into a Redpen session without going to api.github.com.
+pub(crate) async fn create_review_comment(
+    State(s): State<ServerState>,
+    Path((owner, repo, number)): Path<(String, String, u64)>,
+    headers: HeaderMap,
+    Json(body): Json<HashMap<String, Value>>,
+) -> Result<(StatusCode, Json<Value>), StatusCode> {
+    let session = s
+        .backend
+        .find_session_for_pr(&owner, &repo, number)
+        .await
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let agent = bearer_identity(&headers);
+    let path = body
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or(StatusCode::UNPROCESSABLE_ENTITY)?;
+    let line = body
+        .get("line")
+        .and_then(Value::as_u64)
+        .or_else(|| body.get("original_line").and_then(Value::as_u64))
+        .unwrap_or(1) as u32;
+    let text = body
+        .get("body")
+        .and_then(Value::as_str)
+        .ok_or(StatusCode::UNPROCESSABLE_ENTITY)?;
+    match s
+        .backend
+        .append_review_comment(&session.id, &agent, path, line, text)
+        .await
+    {
+        Ok(c) => Ok((StatusCode::CREATED, Json(review_comment_json(&c)))),
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+
+/// `POST /repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies`
+pub(crate) async fn reply_to_comment(
+    State(s): State<ServerState>,
+    Path((owner, repo, number, comment_id)): Path<(String, String, u64, i64)>,
+    headers: HeaderMap,
+    Json(body): Json<HashMap<String, Value>>,
+) -> Result<(StatusCode, Json<Value>), StatusCode> {
+    let session = s
+        .backend
+        .find_session_for_pr(&owner, &repo, number)
+        .await
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let agent = bearer_identity(&headers);
+    let text = body
+        .get("body")
+        .and_then(Value::as_str)
+        .ok_or(StatusCode::UNPROCESSABLE_ENTITY)?;
+    match s
+        .backend
+        .append_reply(&session.id, comment_id, &agent, text)
+        .await
+    {
+        Ok(reply) => Ok((StatusCode::CREATED, Json(review_comment_json(&reply)))),
+        Err(crate::backend::BackendError::NotFound) => Err(StatusCode::NOT_FOUND),
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+
+/// Identity extracted from `Authorization: Bearer <token>`. The token *is*
+/// the identity for v1 — anything goes; loopback-only mitigates spoofing.
+pub(crate) fn bearer_identity(headers: &HeaderMap) -> String {
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| {
+            v.strip_prefix("Bearer ")
+                .or_else(|| v.strip_prefix("token "))
+        })
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .unwrap_or_else(|| "anonymous".to_string())
+}

--- a/crates/redpen-gh-fake/src/shapes.rs
+++ b/crates/redpen-gh-fake/src/shapes.rs
@@ -1,0 +1,51 @@
+//! JSON shape helpers — Redpen types → GitHub-API JSON.
+
+use serde_json::{json, Value};
+
+use crate::backend::{ReviewComment, SessionRef};
+
+pub fn pr_json(s: &SessionRef) -> Value {
+    json!({
+        "number": s.number,
+        "title": s.title,
+        "body": s.body,
+        "html_url": s.html_url,
+        "state": "open",
+        "head": {
+            "ref": s.head_ref,
+            "sha": s.head_sha,
+            "label": format!("{}:{}", s.owner, s.head_ref),
+            "user": { "login": s.author_login },
+            "repo": { "full_name": format!("{}/{}", s.owner, s.repo) },
+        },
+        "base": {
+            "ref": s.base_ref,
+            "sha": s.base_sha,
+            "label": format!("{}:{}", s.owner, s.base_ref),
+            "repo": { "full_name": format!("{}/{}", s.owner, s.repo) },
+        },
+        "user": { "login": s.author_login },
+        "draft": false,
+    })
+}
+
+pub fn review_comment_json(c: &ReviewComment) -> Value {
+    let mut obj = json!({
+        "id": c.database_id,
+        "node_id": c.node_id,
+        "path": c.path,
+        "line": c.line,
+        "original_line": c.line,
+        "diff_hunk": c.diff_hunk,
+        "body": c.body,
+        "user": { "login": c.author },
+        "created_at": c.created_at.to_rfc3339(),
+        "updated_at": c.updated_at.to_rfc3339(),
+        "html_url": c.html_url,
+        "side": "RIGHT",
+    });
+    if let Some(parent) = c.in_reply_to_database_id {
+        obj["in_reply_to_id"] = json!(parent);
+    }
+    obj
+}

--- a/crates/redpen-gh-fake/src/test_backend.rs
+++ b/crates/redpen-gh-fake/src/test_backend.rs
@@ -1,0 +1,247 @@
+//! In-memory `GhBackend` for tests and examples.
+//!
+//! Not intended for production. Sessions, comments, and threads are stored
+//! in a single mutex-guarded struct.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+
+use crate::backend::{BackendError, GhBackend, ReviewComment, SessionRef, ThreadRef};
+
+#[derive(Default)]
+struct Inner {
+    sessions: Vec<SessionRef>,
+    comments: Vec<(String, ReviewComment)>, // (session_id, comment)
+    threads: Vec<(String, ThreadRef)>,      // (session_id, thread)
+    next_database_id: i64,
+}
+
+#[derive(Clone, Default)]
+pub struct TestBackend {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl TestBackend {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                next_database_id: 1_000_000,
+                ..Default::default()
+            })),
+        }
+    }
+
+    pub fn add_session(&self, session: SessionRef) {
+        self.inner.lock().unwrap().sessions.push(session);
+    }
+
+    /// Seed a root review comment + corresponding thread. Returns the comment.
+    pub fn seed_comment(
+        &self,
+        session_id: &str,
+        path: &str,
+        line: u32,
+        body: &str,
+        author: &str,
+    ) -> ReviewComment {
+        let mut inner = self.inner.lock().unwrap();
+        let database_id = inner.next_database_id;
+        inner.next_database_id += 1;
+        let node_id = format!("PRRC_{}", database_id);
+        let thread_node_id = format!("PRRT_{}", database_id);
+        let now = Utc::now();
+        let comment = ReviewComment {
+            database_id,
+            node_id: node_id.clone(),
+            thread_id: thread_node_id.clone(),
+            path: path.to_string(),
+            line,
+            diff_hunk: format!("@@ -{0},1 +{0},1 @@", line),
+            body: body.to_string(),
+            author: author.to_string(),
+            created_at: now,
+            updated_at: now,
+            in_reply_to_database_id: None,
+            html_url: format!("redpen://comment/{}", database_id),
+        };
+        inner.comments.push((session_id.to_string(), comment.clone()));
+        inner.threads.push((
+            session_id.to_string(),
+            ThreadRef {
+                node_id: thread_node_id,
+                is_resolved: false,
+                root_database_id: database_id,
+            },
+        ));
+        comment
+    }
+
+    /// Snapshot all comments for a session — used by tests to assert state.
+    pub fn comments_for(&self, session_id: &str) -> Vec<ReviewComment> {
+        self.inner
+            .lock()
+            .unwrap()
+            .comments
+            .iter()
+            .filter(|(sid, _)| sid == session_id)
+            .map(|(_, c)| c.clone())
+            .collect()
+    }
+
+    pub fn threads_for(&self, session_id: &str) -> Vec<ThreadRef> {
+        self.inner
+            .lock()
+            .unwrap()
+            .threads
+            .iter()
+            .filter(|(sid, _)| sid == session_id)
+            .map(|(_, t)| t.clone())
+            .collect()
+    }
+}
+
+#[async_trait]
+impl GhBackend for TestBackend {
+    async fn find_session_for_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+    ) -> Option<SessionRef> {
+        self.inner
+            .lock()
+            .unwrap()
+            .sessions
+            .iter()
+            .find(|s| s.owner == owner && s.repo == repo && s.head_ref == branch)
+            .cloned()
+    }
+
+    async fn find_session_for_pr(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+    ) -> Option<SessionRef> {
+        self.inner
+            .lock()
+            .unwrap()
+            .sessions
+            .iter()
+            .find(|s| s.owner == owner && s.repo == repo && s.number == number)
+            .cloned()
+    }
+
+    async fn list_active_sessions(&self) -> Vec<SessionRef> {
+        self.inner.lock().unwrap().sessions.clone()
+    }
+
+    async fn list_review_comments(&self, session_id: &str) -> Vec<ReviewComment> {
+        self.comments_for(session_id)
+    }
+
+    async fn list_threads(&self, session_id: &str) -> Vec<ThreadRef> {
+        self.threads_for(session_id)
+    }
+
+    async fn append_review_comment(
+        &self,
+        session_id: &str,
+        agent: &str,
+        path: &str,
+        line: u32,
+        body: &str,
+    ) -> Result<ReviewComment, BackendError> {
+        let mut inner = self.inner.lock().unwrap();
+        // Verify the session exists.
+        if !inner.sessions.iter().any(|s| s.id == session_id) {
+            return Err(BackendError::NotFound);
+        }
+        let database_id = inner.next_database_id;
+        inner.next_database_id += 1;
+        let node_id = format!("PRRC_{}", database_id);
+        let thread_node_id = format!("PRRT_{}", database_id);
+        let now = Utc::now();
+        let comment = ReviewComment {
+            database_id,
+            node_id: node_id.clone(),
+            thread_id: thread_node_id.clone(),
+            path: path.to_string(),
+            line,
+            diff_hunk: format!("@@ -{0},1 +{0},1 @@", line),
+            body: body.to_string(),
+            author: agent.to_string(),
+            created_at: now,
+            updated_at: now,
+            in_reply_to_database_id: None,
+            html_url: format!("redpen://comment/{}", database_id),
+        };
+        inner.comments.push((session_id.to_string(), comment.clone()));
+        inner.threads.push((
+            session_id.to_string(),
+            ThreadRef {
+                node_id: thread_node_id,
+                is_resolved: false,
+                root_database_id: database_id,
+            },
+        ));
+        Ok(comment)
+    }
+
+    async fn append_reply(
+        &self,
+        session_id: &str,
+        parent_database_id: i64,
+        agent: &str,
+        body: &str,
+    ) -> Result<ReviewComment, BackendError> {
+        let mut inner = self.inner.lock().unwrap();
+        // Verify parent exists in this session, copy its path/line/thread_id.
+        let parent = inner
+            .comments
+            .iter()
+            .find(|(sid, c)| sid == session_id && c.database_id == parent_database_id)
+            .map(|(_, c)| c.clone())
+            .ok_or(BackendError::NotFound)?;
+        let database_id = inner.next_database_id;
+        inner.next_database_id += 1;
+        let now = Utc::now();
+        let reply = ReviewComment {
+            database_id,
+            node_id: format!("PRRC_{}", database_id),
+            thread_id: parent.thread_id.clone(),
+            path: parent.path.clone(),
+            line: parent.line,
+            diff_hunk: parent.diff_hunk.clone(),
+            body: body.to_string(),
+            author: agent.to_string(),
+            created_at: now,
+            updated_at: now,
+            in_reply_to_database_id: Some(parent_database_id),
+            html_url: format!("redpen://comment/{}", database_id),
+        };
+        inner.comments.push((session_id.to_string(), reply.clone()));
+        Ok(reply)
+    }
+
+    async fn set_thread_resolved(
+        &self,
+        _session_id: &str,
+        thread_node_id: &str,
+        resolved: bool,
+    ) -> Result<ThreadRef, BackendError> {
+        let mut inner = self.inner.lock().unwrap();
+        let thread = inner
+            .threads
+            .iter_mut()
+            .find(|(_, t)| t.node_id == thread_node_id)
+            .map(|(_, t)| {
+                t.is_resolved = resolved;
+                t.clone()
+            })
+            .ok_or(BackendError::NotFound)?;
+        Ok(thread)
+    }
+}

--- a/crates/redpen-gh-fake/tests/clients/package-lock.json
+++ b/crates/redpen-gh-fake/tests/clients/package-lock.json
@@ -1,0 +1,227 @@
+{
+  "name": "redpen-gh-fake-test-clients",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "redpen-gh-fake-test-clients",
+      "version": "0.0.0",
+      "dependencies": {
+        "@octokit/rest": "^21"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
+      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.2.2",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+      "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^6.1.4",
+        "@octokit/plugin-paginate-rest": "^11.4.2",
+        "@octokit/plugin-request-log": "^5.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/crates/redpen-gh-fake/tests/clients/package.json
+++ b/crates/redpen-gh-fake/tests/clients/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "redpen-gh-fake-test-clients",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Test fixtures for redpen-gh-fake — installs @octokit/rest for the Node integration test.",
+  "dependencies": {
+    "@octokit/rest": "^21"
+  }
+}

--- a/crates/redpen-gh-fake/tests/clients/test_gh_cli.sh
+++ b/crates/redpen-gh-fake/tests/clients/test_gh_cli.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Exercise the fake GitHub server via the real `gh` CLI.
+#
+# Required env: GH_HOST (host:port), GH_TOKEN, SSL_CERT_FILE (PEM trust),
+# PARENT_ID (numeric id of the seeded comment).
+#
+# Exits 0 on success.
+
+set -euo pipefail
+
+: "${GH_HOST:?required}"
+: "${GH_TOKEN:?required}"
+: "${SSL_CERT_FILE:?required}"
+: "${PARENT_ID:?required}"
+
+# 1. List PRs by branch.
+prs_json="$(gh api "repos/octocat/hello/pulls?head=octocat:feature/hello&state=open")"
+pr_number="$(echo "$prs_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["number"])')"
+if [[ "$pr_number" != "42" ]]; then
+  echo "gh: expected PR 42, got $pr_number" >&2
+  exit 1
+fi
+echo "gh: list pulls OK (number=$pr_number)"
+
+# 2. List review comments.
+comments_json="$(gh api "repos/octocat/hello/pulls/42/comments")"
+ids="$(echo "$comments_json" | python3 -c 'import json,sys; print(",".join(str(c["id"]) for c in json.load(sys.stdin)))')"
+if [[ "$ids" != "$PARENT_ID" ]]; then
+  echo "gh: expected ids=$PARENT_ID got $ids" >&2
+  exit 1
+fi
+echo "gh: list comments OK (id=$ids)"
+
+# 3. Reply via gh api.
+reply_json="$(gh api -X POST \
+  "repos/octocat/hello/pulls/42/comments/${PARENT_ID}/replies" \
+  -f body='fixed via gh CLI')"
+reply_parent="$(echo "$reply_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)["in_reply_to_id"])')"
+if [[ "$reply_parent" != "$PARENT_ID" ]]; then
+  echo "gh: reply parent mismatch (got $reply_parent, expected $PARENT_ID)" >&2
+  exit 1
+fi
+echo "gh: posted reply OK (in_reply_to_id=$reply_parent)"
+
+# 4. GraphQL resolveReviewThread (using gh api graphql).
+thread_id="$(gh api graphql \
+  -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){nodes{id isResolved}}}}}' \
+  -F owner=octocat -F repo=hello -F pr=42 \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"][0]["id"])')"
+echo "gh: graphql found thread $thread_id"
+
+resolved="$(gh api graphql \
+  -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id isResolved}}}' \
+  -F threadId="$thread_id" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["data"]["resolveReviewThread"]["thread"]["isResolved"])')"
+if [[ "$resolved" != "True" ]]; then
+  echo "gh: thread not resolved (got $resolved)" >&2
+  exit 1
+fi
+echo "gh: resolved thread OK"

--- a/crates/redpen-gh-fake/tests/clients/test_node.js
+++ b/crates/redpen-gh-fake/tests/clients/test_node.js
@@ -1,0 +1,132 @@
+// Exercise the fake GitHub server end-to-end from Node.
+// Prefers @octokit/rest (real GitHub library) if installed in this dir;
+// always also runs a built-in fetch round-trip for the GraphQL bits.
+//
+// Reads BASE_URL and PARENT_ID from env. Exits 0 on success.
+
+"use strict";
+
+const path = require("path");
+
+const BASE = process.env.BASE_URL;
+const PARENT_ID = Number(process.env.PARENT_ID);
+const TOKEN = process.env.GH_FAKE_TOKEN || "node-agent";
+
+if (!BASE || !PARENT_ID) {
+  console.error("BASE_URL and PARENT_ID must be set");
+  process.exit(2);
+}
+
+async function runWithOctokit() {
+  let Octokit;
+  // @octokit/rest v21+ ships ESM-only — use dynamic import from this CJS file.
+  try {
+    const mod = await import(
+      path.join(__dirname, "node_modules", "@octokit", "rest", "dist-src", "index.js")
+    );
+    Octokit = mod.Octokit;
+  } catch (e) {
+    console.error("@octokit/rest not loadable in tests/clients; skipping octokit path:", e.message);
+    return false;
+  }
+
+  const octokit = new Octokit({ auth: TOKEN, baseUrl: BASE });
+
+  const { data: prs } = await octokit.pulls.list({
+    owner: "octocat",
+    repo: "hello",
+    head: "octocat:feature/hello",
+    state: "open",
+  });
+  if (prs.length !== 1 || prs[0].number !== 42) {
+    throw new Error(`octokit: expected PR 42, got ${JSON.stringify(prs)}`);
+  }
+  console.log("octokit: list pulls OK");
+
+  const { data: comments } = await octokit.pulls.listReviewComments({
+    owner: "octocat",
+    repo: "hello",
+    pull_number: 42,
+  });
+  if (comments.length < 1 || comments[0].id !== PARENT_ID) {
+    throw new Error(`octokit: comment id mismatch: ${JSON.stringify(comments)}`);
+  }
+  console.log(`octokit: list comments OK (id=${comments[0].id})`);
+
+  const { data: reply } = await octokit.pulls.createReplyForReviewComment({
+    owner: "octocat",
+    repo: "hello",
+    pull_number: 42,
+    comment_id: PARENT_ID,
+    body: "fixed (via octokit)",
+  });
+  if (reply.in_reply_to_id !== PARENT_ID) {
+    throw new Error(`octokit: in_reply_to_id mismatch: ${JSON.stringify(reply)}`);
+  }
+  console.log(`octokit: posted reply id=${reply.id}`);
+  return true;
+}
+
+async function runWithFetch() {
+  const headers = {
+    Authorization: `Bearer ${TOKEN}`,
+    "Content-Type": "application/json",
+    Accept: "application/vnd.github.v3+json",
+  };
+
+  // GraphQL: find thread.
+  const findQuery = `
+    query($owner:String!,$repo:String!,$pr:Int!) {
+      repository(owner:$owner,name:$repo) {
+        pullRequest(number:$pr) {
+          reviewThreads(first:100) {
+            nodes { id isResolved comments(first:1) { nodes { databaseId } } }
+          }
+        }
+      }
+    }`;
+  let r = await fetch(`${BASE}/graphql`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      query: findQuery,
+      variables: { owner: "octocat", repo: "hello", pr: 42 },
+    }),
+  });
+  if (!r.ok) throw new Error(`graphql find: ${r.status}`);
+  const findData = await r.json();
+  const nodes = findData.data.repository.pullRequest.reviewThreads.nodes;
+  if (nodes.length !== 1) {
+    throw new Error(`graphql: expected 1 thread, got ${nodes.length}`);
+  }
+  const threadId = nodes[0].id;
+  console.log(`fetch: graphql found thread ${threadId}`);
+
+  // GraphQL: resolve.
+  const resolveMutation = `
+    mutation($threadId: ID!) {
+      resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } }
+    }`;
+  r = await fetch(`${BASE}/graphql`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      query: resolveMutation,
+      variables: { threadId },
+    }),
+  });
+  if (!r.ok) throw new Error(`graphql resolve: ${r.status}`);
+  const resolveData = await r.json();
+  if (!resolveData.data.resolveReviewThread.thread.isResolved) {
+    throw new Error(`graphql: thread not marked resolved`);
+  }
+  console.log(`fetch: resolved thread ${threadId}`);
+}
+
+(async () => {
+  await runWithOctokit();
+  await runWithFetch();
+})().catch((e) => {
+  console.error("FAIL:", e.message);
+  process.exit(1);
+});

--- a/crates/redpen-gh-fake/tests/clients/test_python.py
+++ b/crates/redpen-gh-fake/tests/clients/test_python.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Exercise the fake GitHub server end-to-end from Python.
+
+Prefers PyGithub (real GitHub library) if installed; falls back to stdlib
+urllib for environments without it. Reads BASE_URL and PARENT_ID from env.
+
+Exit code 0 on full success; non-zero with a diagnostic on any failure.
+"""
+import json
+import os
+import sys
+import urllib.request
+
+BASE = os.environ["BASE_URL"]
+PARENT_ID = int(os.environ["PARENT_ID"])
+TOKEN = os.environ.get("GH_FAKE_TOKEN", "py-agent")
+
+
+def _req(method, path, body=None):
+    url = f"{BASE}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {TOKEN}",
+            "Accept": "application/vnd.github.v3+json",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req) as r:
+        return r.status, json.loads(r.read() or b"null")
+
+
+def run_with_pygithub():
+    from github import Github, Auth  # type: ignore
+
+    gh = Github(base_url=BASE, auth=Auth.Token(TOKEN))
+    repo = gh.get_repo("octocat/hello")
+    pr = repo.get_pull(42)
+
+    # List review comments via the library.
+    comments = list(pr.get_review_comments())
+    if not comments:
+        raise SystemExit("PyGithub: expected >=1 seeded comment")
+    print(f"pygithub: listed {len(comments)} comment(s)")
+
+    # PyGithub doesn't have a clean reply API in older versions; use the raw
+    # API via the lib's requester to keep this test independent of version.
+    headers, data = pr._requester.requestJsonAndCheck(
+        "POST",
+        f"{BASE}/repos/octocat/hello/pulls/42/comments/{PARENT_ID}/replies",
+        input={"body": "fixed (via PyGithub)"},
+    )
+    print(f"pygithub: posted reply id={data.get('id')}")
+    if not data.get("id"):
+        raise SystemExit("PyGithub: reply missing id")
+    return True
+
+
+def run_with_stdlib():
+    # 1. List PRs by branch.
+    status, prs = _req("GET", "/repos/octocat/hello/pulls?head=octocat:feature/hello&state=open")
+    assert status == 200, f"list pulls: {status}"
+    assert len(prs) == 1, f"expected 1 PR, got {len(prs)}"
+    assert prs[0]["number"] == 42, prs
+    print(f"stdlib: list pulls OK (number={prs[0]['number']})")
+
+    # 2. List review comments.
+    status, comments = _req("GET", "/repos/octocat/hello/pulls/42/comments")
+    assert status == 200
+    assert len(comments) >= 1
+    parent = comments[0]
+    assert parent["id"] == PARENT_ID, f"expected id {PARENT_ID}, got {parent['id']}"
+    print(f"stdlib: list comments OK ({len(comments)} comment(s))")
+
+    # 3. Reply.
+    status, reply = _req(
+        "POST",
+        f"/repos/octocat/hello/pulls/42/comments/{PARENT_ID}/replies",
+        body={"body": "fixed via python stdlib"},
+    )
+    assert status == 201, f"reply: {status}"
+    assert reply["in_reply_to_id"] == PARENT_ID
+    assert reply["user"]["login"] == TOKEN
+    print(f"stdlib: posted reply id={reply['id']}")
+
+    # 4. GraphQL: find thread.
+    query = """
+        query($owner:String!,$repo:String!,$pr:Int!) {
+          repository(owner:$owner,name:$repo) {
+            pullRequest(number:$pr) {
+              reviewThreads(first:100) {
+                nodes { id isResolved comments(first:1) { nodes { databaseId } } }
+              }
+            }
+          }
+        }
+    """
+    status, gql = _req(
+        "POST",
+        "/graphql",
+        body={"query": query, "variables": {"owner": "octocat", "repo": "hello", "pr": 42}},
+    )
+    assert status == 200
+    nodes = gql["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    assert len(nodes) == 1, nodes
+    thread_id = nodes[0]["id"]
+    print(f"stdlib: graphql found thread {thread_id}")
+
+    # 5. GraphQL: resolve.
+    mutation = """
+        mutation($threadId: ID!) {
+          resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } }
+        }
+    """
+    status, gql = _req(
+        "POST",
+        "/graphql",
+        body={"query": mutation, "variables": {"threadId": thread_id}},
+    )
+    assert status == 200
+    assert gql["data"]["resolveReviewThread"]["thread"]["isResolved"] is True
+    print(f"stdlib: resolved thread {thread_id}")
+    return True
+
+
+def main():
+    try:
+        import github  # noqa: F401
+    except ImportError:
+        print("PyGithub not installed; using stdlib client.", file=sys.stderr)
+        return run_with_stdlib()
+    return run_with_pygithub() and run_with_stdlib()
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/redpen-gh-fake/tests/common/mod.rs
+++ b/crates/redpen-gh-fake/tests/common/mod.rs
@@ -1,0 +1,100 @@
+//! Shared test helpers: spawn a seeded server (HTTP or HTTPS), kill it on drop.
+
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use axum_server::tls_rustls::RustlsConfig;
+use redpen_gh_fake::{test_backend::TestBackend, ReviewComment, SessionRef};
+
+pub struct SpawnedServer {
+    pub base_url: String,
+    pub backend: TestBackend,
+    pub seeded_comment: ReviewComment,
+    pub cert_pem: Option<String>,
+    _shutdown: tokio::sync::oneshot::Sender<()>,
+}
+
+pub fn default_session() -> SessionRef {
+    SessionRef {
+        id: "session-1".into(),
+        owner: "octocat".into(),
+        repo: "hello".into(),
+        number: 42,
+        title: "Add greeting".into(),
+        body: "Adds a hello message.".into(),
+        head_ref: "feature/hello".into(),
+        head_sha: "deadbeef".into(),
+        base_ref: "main".into(),
+        base_sha: "cafebabe".into(),
+        author_login: "octocat".into(),
+        viewer_login: "reviewer".into(),
+        html_url: "redpen://session/session-1".into(),
+    }
+}
+
+pub async fn spawn_http() -> SpawnedServer {
+    let backend = TestBackend::new();
+    let session = default_session();
+    backend.add_session(session.clone());
+    let seeded = backend.seed_comment(&session.id, "src/foo.rs", 10, "nit", "alice");
+
+    let (addr, _handle) = redpen_gh_fake::bind(Arc::new(backend.clone()), 0)
+        .await
+        .expect("bind http");
+    let (tx, _rx) = tokio::sync::oneshot::channel();
+    SpawnedServer {
+        base_url: format!("http://{}", addr),
+        backend,
+        seeded_comment: seeded,
+        cert_pem: None,
+        _shutdown: tx,
+    }
+}
+
+/// Spawn an HTTPS server with a self-signed cert for `127.0.0.1`. Returns the
+/// PEM-encoded cert so the test can pass it to clients via `SSL_CERT_FILE` etc.
+pub async fn spawn_https() -> SpawnedServer {
+    // rustls needs a default crypto provider installed once per process.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let backend = TestBackend::new();
+    let session = default_session();
+    backend.add_session(session.clone());
+    let seeded = backend.seed_comment(&session.id, "src/foo.rs", 10, "nit", "alice");
+
+    let cert = rcgen::generate_simple_self_signed(vec!["127.0.0.1".into(), "localhost".into()])
+        .expect("self-signed cert");
+    let cert_pem = cert.cert.pem();
+    let key_pem = cert.key_pair.serialize_pem();
+
+    let config = RustlsConfig::from_pem(cert_pem.clone().into_bytes(), key_pem.into_bytes())
+        .await
+        .expect("rustls config");
+
+    // Discover an ephemeral port via std listener, then bind axum-server.
+    let std_listener = std::net::TcpListener::bind("127.0.0.1:0").expect("ephemeral");
+    let addr = std_listener.local_addr().unwrap();
+    drop(std_listener);
+
+    let app = redpen_gh_fake::router(Arc::new(backend.clone()));
+    let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let server = axum_server::bind_rustls(addr, config).serve(app.into_make_service());
+        tokio::select! {
+            _ = server => {},
+            _ = &mut rx => {},
+        }
+    });
+
+    // Tiny settle so the listener is accepting before tests fire.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    SpawnedServer {
+        base_url: format!("https://{}", addr),
+        backend,
+        seeded_comment: seeded,
+        cert_pem: Some(cert_pem),
+        _shutdown: tx,
+    }
+}

--- a/crates/redpen-gh-fake/tests/external_clients.rs
+++ b/crates/redpen-gh-fake/tests/external_clients.rs
@@ -1,0 +1,179 @@
+//! End-to-end tests using *external* GitHub clients (real binaries, not Rust):
+//!   - the `gh` CLI (https + GHE-style /api/v3 paths via `GH_HOST`)
+//!   - a Python script (PyGithub if installed, else stdlib urllib)
+//!   - a Node script (Octokit if installed via `npm ci`, plus built-in fetch)
+//!
+//! These tests confirm the wire shape is genuinely GitHub-compatible — not
+//! just "Rust talking to Rust over JSON".
+//!
+//! Tests skip with a print (rather than fail) when the required tool isn't
+//! available in the environment, so `cargo test` still passes on minimal hosts.
+
+mod common;
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+fn clients_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("clients")
+}
+
+async fn tool_available(tool: &str) -> bool {
+    Command::new("which")
+        .arg(tool)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+async fn run_cmd(mut cmd: Command, label: &str) -> Result<String, String> {
+    let out = cmd.output().await.map_err(|e| format!("{label}: {e}"))?;
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    if !out.status.success() {
+        return Err(format!(
+            "{label} exit={:?}\nstdout:\n{}\nstderr:\n{}",
+            out.status.code(),
+            stdout,
+            stderr
+        ));
+    }
+    Ok(format!("{stdout}{stderr}"))
+}
+
+#[tokio::test]
+async fn python_client_round_trip() {
+    if !tool_available("python3").await {
+        eprintln!("python3 not on PATH; skipping");
+        return;
+    }
+    let server = common::spawn_http().await;
+    let mut cmd = Command::new("python3");
+    cmd.arg(clients_dir().join("test_python.py"))
+        .env("BASE_URL", &server.base_url)
+        .env("PARENT_ID", server.seeded_comment.database_id.to_string())
+        .env("GH_FAKE_TOKEN", "py-agent")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let out = run_cmd(cmd, "python3 test_python.py").await.expect("python");
+    eprintln!("--- python output ---\n{out}");
+
+    // Side-effect verification: the python script posted a reply.
+    let comments = server.backend.comments_for("session-1");
+    assert!(
+        comments.iter().any(|c| c.author == "py-agent"),
+        "expected a reply authored by py-agent, got: {:?}",
+        comments.iter().map(|c| &c.author).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn node_client_round_trip() {
+    if !tool_available("node").await {
+        eprintln!("node not on PATH; skipping");
+        return;
+    }
+    if !tool_available("npm").await {
+        eprintln!("npm not on PATH; skipping");
+        return;
+    }
+
+    // Lazy-install @octokit/rest into tests/clients/. Idempotent + fast on
+    // re-run thanks to npm's cache + node_modules check.
+    let install = Command::new("npm")
+        .arg("install")
+        .arg("--no-fund")
+        .arg("--no-audit")
+        .arg("--silent")
+        .current_dir(clients_dir())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .status()
+        .await;
+    if !matches!(install, Ok(s) if s.success()) {
+        eprintln!("npm install failed; running test without octokit (fetch-only)");
+    }
+
+    let server = common::spawn_http().await;
+    let mut cmd = Command::new("node");
+    cmd.arg(clients_dir().join("test_node.js"))
+        .env("BASE_URL", &server.base_url)
+        .env("PARENT_ID", server.seeded_comment.database_id.to_string())
+        .env("GH_FAKE_TOKEN", "node-agent")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let out = run_cmd(cmd, "node test_node.js").await.expect("node");
+    eprintln!("--- node output ---\n{out}");
+
+    // Side-effect: thread should now be resolved (mutation runs unconditionally).
+    let threads = server.backend.threads_for("session-1");
+    assert!(
+        threads.iter().any(|t| t.is_resolved),
+        "expected at least one resolved thread"
+    );
+}
+
+#[tokio::test]
+async fn gh_cli_round_trip_via_tls() {
+    if !tool_available("gh").await {
+        eprintln!("gh not on PATH; skipping");
+        return;
+    }
+    // Go's TLS on macOS uses Security.framework and ignores SSL_CERT_FILE,
+    // so a self-signed cert won't be trusted unless it's been added to the
+    // keychain manually (`security add-trusted-cert`) or generated via
+    // `mkcert -install`. Skip cleanly rather than fail on developer machines.
+    #[cfg(target_os = "macos")]
+    {
+        eprintln!(
+            "gh CLI test skipped on macOS: gh's Go runtime ignores SSL_CERT_FILE here. \
+             Enable on Linux CI, or run `brew install mkcert && mkcert -install` and \
+             rerun with REDPEN_GH_FAKE_FORCE_GH_TEST=1."
+        );
+        if std::env::var_os("REDPEN_GH_FAKE_FORCE_GH_TEST").is_none() {
+            return;
+        }
+    }
+
+    let server = common::spawn_https().await;
+    let cert_pem = server.cert_pem.clone().expect("https spawn returned cert");
+    let cert_path = std::env::temp_dir().join(format!("redpen-gh-fake-{}.pem", std::process::id()));
+    let mut f = tokio::fs::File::create(&cert_path).await.unwrap();
+    f.write_all(cert_pem.as_bytes()).await.unwrap();
+    drop(f);
+
+    // GH_HOST strips the scheme; gh prepends https://.
+    let host = server.base_url.trim_start_matches("https://");
+
+    let mut cmd = Command::new("bash");
+    cmd.arg(clients_dir().join("test_gh_cli.sh"))
+        .env("GH_HOST", host)
+        .env("GH_TOKEN", "gh-agent")
+        .env("SSL_CERT_FILE", &cert_path)
+        // On macOS Go uses Security.framework by default; the fallback flag
+        // forces honoring SSL_CERT_FILE.
+        .env("GODEBUG", "x509usefallbackroots=1")
+        .env("PARENT_ID", server.seeded_comment.database_id.to_string())
+        .env("GH_PROMPT_DISABLED", "1")
+        .env("NO_COLOR", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let result = run_cmd(cmd, "gh CLI test").await;
+    let _ = tokio::fs::remove_file(&cert_path).await;
+    let out = result.expect("gh");
+    eprintln!("--- gh output ---\n{out}");
+
+    let threads = server.backend.threads_for("session-1");
+    assert!(
+        threads.iter().any(|t| t.is_resolved),
+        "expected at least one resolved thread after gh CLI run"
+    );
+}

--- a/crates/redpen-gh-fake/tests/rust_native.rs
+++ b/crates/redpen-gh-fake/tests/rust_native.rs
@@ -1,0 +1,330 @@
+//! End-to-end tests using `reqwest` against a spawned server.
+//! Covers every endpoint agent-reviews touches.
+
+use std::sync::Arc;
+
+use redpen_gh_fake::test_backend::TestBackend;
+use redpen_gh_fake::SessionRef;
+use serde_json::{json, Value};
+
+async fn spawn() -> (String, TestBackend) {
+    let backend = TestBackend::new();
+    let (addr, _handle) = redpen_gh_fake::bind(Arc::new(backend.clone()), 0)
+        .await
+        .expect("bind");
+    (format!("http://{}", addr), backend)
+}
+
+fn seed_pr(backend: &TestBackend) -> SessionRef {
+    let session = SessionRef {
+        id: "session-1".into(),
+        owner: "octocat".into(),
+        repo: "hello".into(),
+        number: 42,
+        title: "Add greeting".into(),
+        body: "Adds a hello message.".into(),
+        head_ref: "feature/hello".into(),
+        head_sha: "deadbeef".into(),
+        base_ref: "main".into(),
+        base_sha: "cafebabe".into(),
+        author_login: "octocat".into(),
+        viewer_login: "reviewer".into(),
+        html_url: "redpen://session/session-1".into(),
+    };
+    backend.add_session(session.clone());
+    session
+}
+
+#[tokio::test]
+async fn list_pulls_by_branch_returns_session() {
+    let (base, backend) = spawn().await;
+    let session = seed_pr(&backend);
+
+    let url = format!(
+        "{}/repos/{}/{}/pulls?head={}:{}&state=open",
+        base, session.owner, session.repo, session.owner, session.head_ref
+    );
+    let resp: Vec<Value> = reqwest::get(&url).await.unwrap().json().await.unwrap();
+    assert_eq!(resp.len(), 1);
+    assert_eq!(resp[0]["number"], 42);
+    assert_eq!(resp[0]["head"]["ref"], "feature/hello");
+    assert_eq!(resp[0]["base"]["ref"], "main");
+}
+
+#[tokio::test]
+async fn list_pulls_unknown_branch_returns_empty() {
+    let (base, backend) = spawn().await;
+    seed_pr(&backend);
+
+    let url = format!(
+        "{}/repos/octocat/hello/pulls?head=octocat:nope&state=open",
+        base
+    );
+    let resp: Vec<Value> = reqwest::get(&url).await.unwrap().json().await.unwrap();
+    assert!(resp.is_empty());
+}
+
+#[tokio::test]
+async fn list_review_comments_returns_seeded() {
+    let (base, backend) = spawn().await;
+    let session = seed_pr(&backend);
+    let seeded = backend.seed_comment(&session.id, "src/foo.rs", 10, "nit", "alice");
+
+    let url = format!("{}/repos/octocat/hello/pulls/42/comments", base);
+    let resp: Vec<Value> = reqwest::get(&url).await.unwrap().json().await.unwrap();
+    assert_eq!(resp.len(), 1);
+    assert_eq!(resp[0]["id"], seeded.database_id);
+    assert_eq!(resp[0]["path"], "src/foo.rs");
+    assert_eq!(resp[0]["line"], 10);
+    assert_eq!(resp[0]["body"], "nit");
+    assert_eq!(resp[0]["user"]["login"], "alice");
+    // No `in_reply_to_id` for root comments.
+    assert!(resp[0].get("in_reply_to_id").is_none());
+}
+
+#[tokio::test]
+async fn issue_comments_and_reviews_are_empty() {
+    let (base, backend) = spawn().await;
+    seed_pr(&backend);
+
+    for path in [
+        "/repos/octocat/hello/issues/42/comments",
+        "/repos/octocat/hello/pulls/42/reviews",
+    ] {
+        let url = format!("{}{}", base, path);
+        let resp: Vec<Value> = reqwest::get(&url).await.unwrap().json().await.unwrap();
+        assert!(resp.is_empty(), "{} should be empty", path);
+    }
+}
+
+#[tokio::test]
+async fn reply_to_comment_persists_and_round_trips() {
+    let (base, backend) = spawn().await;
+    let session = seed_pr(&backend);
+    let parent = backend.seed_comment(&session.id, "src/foo.rs", 10, "nit", "alice");
+
+    let client = reqwest::Client::new();
+    let post = client
+        .post(format!(
+            "{}/repos/octocat/hello/pulls/42/comments/{}/replies",
+            base, parent.database_id
+        ))
+        .bearer_auth("redpen-agent")
+        .json(&json!({ "body": "fixed in abc123" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(post.status(), 201);
+    let reply: Value = post.json().await.unwrap();
+    assert_eq!(reply["body"], "fixed in abc123");
+    assert_eq!(reply["in_reply_to_id"], parent.database_id);
+    // Identity comes from the bearer token.
+    assert_eq!(reply["user"]["login"], "redpen-agent");
+
+    // Round-trip: fetching all comments now returns parent + reply.
+    let listing: Vec<Value> = reqwest::get(format!(
+        "{}/repos/octocat/hello/pulls/42/comments",
+        base
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+    assert_eq!(listing.len(), 2);
+}
+
+#[tokio::test]
+async fn reply_to_unknown_comment_404s() {
+    let (base, backend) = spawn().await;
+    seed_pr(&backend);
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/repos/octocat/hello/pulls/42/comments/999999/replies",
+            base
+        ))
+        .bearer_auth("x")
+        .json(&json!({ "body": "" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test]
+async fn graphql_find_thread_returns_seeded_thread() {
+    let (base, backend) = spawn().await;
+    let session = seed_pr(&backend);
+    let seeded = backend.seed_comment(&session.id, "src/foo.rs", 10, "nit", "alice");
+
+    let query = r#"
+        query($owner:String!,$repo:String!,$pr:Int!) {
+          repository(owner:$owner,name:$repo) {
+            pullRequest(number:$pr) {
+              reviewThreads(first:100) {
+                pageInfo { hasNextPage endCursor }
+                nodes { id isResolved comments(first:1) { nodes { databaseId } } }
+              }
+            }
+          }
+        }
+    "#;
+    let body = json!({
+        "query": query,
+        "variables": { "owner": "octocat", "repo": "hello", "pr": 42 }
+    });
+
+    let client = reqwest::Client::new();
+    let resp: Value = client
+        .post(format!("{}/graphql", base))
+        .bearer_auth("x")
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let nodes = &resp["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"];
+    assert_eq!(nodes.as_array().unwrap().len(), 1);
+    assert_eq!(nodes[0]["isResolved"], false);
+    assert_eq!(nodes[0]["comments"]["nodes"][0]["databaseId"], seeded.database_id);
+}
+
+#[tokio::test]
+async fn api_v3_prefix_serves_same_routes() {
+    // Sanity: the /api/v3/* mount used by gh's GHE-style clients works.
+    let (base, backend) = spawn().await;
+    let session = seed_pr(&backend);
+    backend.seed_comment(&session.id, "src/foo.rs", 10, "nit", "alice");
+
+    let url = format!("{}/api/v3/repos/octocat/hello/pulls/42/comments", base);
+    let resp: Vec<Value> = reqwest::get(&url).await.unwrap().json().await.unwrap();
+    assert_eq!(resp.len(), 1);
+    assert_eq!(resp[0]["path"], "src/foo.rs");
+}
+
+#[tokio::test]
+async fn create_review_comment_seeds_a_thread() {
+    let (base, backend) = spawn().await;
+    seed_pr(&backend);
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/repos/octocat/hello/pulls/42/comments", base))
+        .bearer_auth("codex-review")
+        .json(&json!({
+            "path": "src/foo.rs",
+            "line": 25,
+            "body": "this allocation is unbounded",
+            "side": "RIGHT",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let comment: Value = resp.json().await.unwrap();
+    assert_eq!(comment["path"], "src/foo.rs");
+    assert_eq!(comment["line"], 25);
+    assert_eq!(comment["user"]["login"], "codex-review");
+    assert!(comment.get("in_reply_to_id").is_none());
+
+    // Listing now returns the seeded comment.
+    let listing: Vec<Value> = reqwest::get(format!(
+        "{}/repos/octocat/hello/pulls/42/comments",
+        base
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+    assert!(listing.iter().any(|c| c["path"] == "src/foo.rs"
+        && c["line"] == 25
+        && c["user"]["login"] == "codex-review"));
+
+    // And it can be replied to via the same id agent-reviews would use.
+    let parent_id = comment["id"].as_i64().unwrap();
+    let reply = client
+        .post(format!(
+            "{}/repos/octocat/hello/pulls/42/comments/{}/replies",
+            base, parent_id
+        ))
+        .bearer_auth("agent-reviews")
+        .json(&json!({ "body": "fixed in HEAD~" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(reply.status(), 201);
+    let reply_json: Value = reply.json().await.unwrap();
+    assert_eq!(reply_json["in_reply_to_id"], parent_id);
+}
+
+#[tokio::test]
+async fn meta_endpoint_describes_active_sessions() {
+    let (base, backend) = spawn().await;
+    let session = seed_pr(&backend);
+    backend.seed_comment(&session.id, "src/foo.rs", 10, "nit", "alice");
+
+    let resp: Value = reqwest::get(format!("{}/redpen/meta", base))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert_eq!(resp["server"], "redpen-gh-fake");
+    assert_eq!(resp["semantics"], "drafts-only");
+    assert!(resp["supported"]["rest"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|p| p.as_str().unwrap().contains("/comments/{id}/replies")));
+    assert!(resp["supported"]["graphql"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|p| p.as_str().unwrap().contains("resolveReviewThread")));
+
+    let sessions = resp["active_sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0]["owner"], "octocat");
+    assert_eq!(sessions[0]["repo"], "hello");
+    assert_eq!(sessions[0]["number"], 42);
+    assert_eq!(sessions[0]["branch"], "feature/hello");
+}
+
+#[tokio::test]
+async fn graphql_resolve_thread_flips_state() {
+    let (base, backend) = spawn().await;
+    let session = seed_pr(&backend);
+    let seeded = backend.seed_comment(&session.id, "src/foo.rs", 10, "nit", "alice");
+    let thread_id = seeded.thread_id.clone();
+
+    let mutation = r#"
+        mutation($threadId: ID!) {
+          resolveReviewThread(input: { threadId: $threadId }) {
+            thread { id isResolved }
+          }
+        }
+    "#;
+    let body = json!({ "query": mutation, "variables": { "threadId": thread_id } });
+
+    let client = reqwest::Client::new();
+    let resp: Value = client
+        .post(format!("{}/graphql", base))
+        .bearer_auth("x")
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert_eq!(resp["data"]["resolveReviewThread"]["thread"]["isResolved"], true);
+    assert!(backend.threads_for(&session.id)[0].is_resolved);
+}

--- a/crates/redpen-server/Cargo.toml
+++ b/crates/redpen-server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 redpen-core = { path = "../redpen-core" }
+redpen-gh-fake = { path = "../redpen-gh-fake" }
 axum = "0.8"
 tokio = { version = "1", features = ["sync", "net", "rt", "macros", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/redpen-server/src/lib.rs
+++ b/crates/redpen-server/src/lib.rs
@@ -537,11 +537,27 @@ pub fn discovery_path() -> std::path::PathBuf {
         .join("server.json")
 }
 
+/// Compose `/rpc/*` and (optionally) GitHub-API-compatible routes into a
+/// single Router. Exposed for tests so the merge can be verified without
+/// binding a TCP listener.
+pub fn build_router_with_gh_fake(
+    bridge: Arc<dyn AppBridge>,
+    sessions: Arc<ReviewSessions>,
+    gh_backend: Option<Arc<dyn redpen_gh_fake::GhBackend>>,
+) -> Router {
+    let mut router = build_router(bridge, sessions);
+    if let Some(backend) = gh_backend {
+        router = router.merge(redpen_gh_fake::router(backend));
+    }
+    router
+}
+
 pub async fn start_server(
     bridge: Arc<dyn AppBridge>,
     sessions: Arc<ReviewSessions>,
+    gh_backend: Option<Arc<dyn redpen_gh_fake::GhBackend>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let router = build_router(bridge, sessions);
+    let router = build_router_with_gh_fake(bridge, sessions, gh_backend);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
@@ -1217,5 +1233,63 @@ mod tests {
         let path = discovery_path();
         assert!(path.to_string_lossy().contains(".config/redpen"));
         assert!(path.to_string_lossy().ends_with("server.json"));
+    }
+
+    // =======================================================================
+    // gh-fake merge
+    // =======================================================================
+
+    #[tokio::test]
+    async fn merged_router_serves_both_rpc_and_gh_routes() {
+        use redpen_gh_fake::test_backend::TestBackend;
+        use redpen_gh_fake::SessionRef;
+
+        let bridge = Arc::new(MockBridge::new());
+        let sessions = Arc::new(ReviewSessions::new());
+        let gh_backend = TestBackend::new();
+        gh_backend.add_session(SessionRef {
+            id: "s".into(),
+            owner: "octocat".into(),
+            repo: "hello".into(),
+            number: 7,
+            title: "t".into(),
+            body: "".into(),
+            head_ref: "feat".into(),
+            head_sha: "h".into(),
+            base_ref: "main".into(),
+            base_sha: "b".into(),
+            author_login: "a".into(),
+            viewer_login: "v".into(),
+            html_url: "redpen://x".into(),
+        });
+
+        let router = build_router_with_gh_fake(bridge, sessions, Some(Arc::new(gh_backend)));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        let base = format!("http://{}", addr);
+        let client = reqwest::Client::new();
+
+        // /rpc/* still works.
+        let rpc = client
+            .post(format!("{}/rpc/get_annotations", base))
+            .json(&serde_json::json!({ "file": "/x.rs" }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(rpc.status(), 200);
+
+        // gh-fake routes are reachable on the same listener.
+        let gh = client
+            .get(format!(
+                "{}/repos/octocat/hello/pulls?head=octocat:feat&state=open",
+                base
+            ))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(gh.status(), 200);
+        let body: serde_json::Value = gh.json().await.unwrap();
+        assert_eq!(body[0]["number"], 7);
     }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ walkdir = "2"
 similar = "2"
 ts-rs = { version = "12", features = ["chrono-impl", "serde-json-impl"] }
 redpen-server = { path = "../crates/redpen-server" }
+redpen-gh-fake = { path = "../crates/redpen-gh-fake" }
+async-trait = "0.1"
 urlencoding = "2"
 rusqlite = { version = "0.32", features = ["bundled"] }
 rusqlite_migration = "1"

--- a/src-tauri/src/commands/github_review.rs
+++ b/src-tauri/src/commands/github_review.rs
@@ -1262,7 +1262,7 @@ fn save_session(
     Ok(())
 }
 
-fn load_session_by_id(db: &StateDb, session_id: &str) -> CommandResult<GitHubPrSession> {
+pub fn load_session_by_id(db: &StateDb, session_id: &str) -> CommandResult<GitHubPrSession> {
     let stored = db
         .get_review_session(session_id)
         .map_err(storage_error)?
@@ -1272,7 +1272,7 @@ fn load_session_by_id(db: &StateDb, session_id: &str) -> CommandResult<GitHubPrS
     github_session_from_stored(stored)
 }
 
-fn list_session_sidecars(session: &GitHubPrSession) -> CommandResult<Vec<(PathBuf, PathBuf)>> {
+pub fn list_session_sidecars(session: &GitHubPrSession) -> CommandResult<Vec<(PathBuf, PathBuf)>> {
     let comments_dir = session_directory(session)?.join("comments");
     if !comments_dir.exists() {
         return Ok(Vec::new());

--- a/src-tauri/src/gh_fake_backend.rs
+++ b/src-tauri/src/gh_fake_backend.rs
@@ -1,0 +1,513 @@
+//! Adapter implementing `redpen_gh_fake::GhBackend` against Tauri-side state.
+//!
+//! Maps fake-GitHub operations onto Redpen sessions:
+//!   * Reads walk session sidecars and surface annotations as PR review comments.
+//!   * Writes (`append_reply`, `set_thread_resolved`) mutate sidecars directly,
+//!     marking new replies as `PendingPublish` so they ride the existing human
+//!     "Submit review" flow when the user is ready.
+//!
+//! Known limitation: comment ids returned to clients are synthetic (a stable
+//! 53-bit hash of the GraphQL node id), and the existing publish path uses
+//! the same node id when posting replies upstream — that's the REST/databaseId
+//! bug tracked as plan §1. Local round-trips work; upstream publish for replies
+//! to imported comments is broken until §1 lands.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use redpen_core::annotation::{
+    Anchor, Annotation, AnnotationKind, GitHubAnnotationMetadata, GitHubSyncState,
+};
+use redpen_core::sidecar::SidecarFile;
+use redpen_gh_fake::{BackendError, GhBackend, ReviewComment, SessionRef, ThreadRef};
+use tauri::{AppHandle, Manager};
+
+use crate::commands::github_review::{
+    list_session_sidecars, load_session_by_id, GitHubPrSession,
+};
+use crate::state::AppState;
+use crate::storage::{ReviewSessionKind, ReviewSessionStatus, StateDb, StoredReviewSession};
+
+const SESSION_LIST_LIMIT: usize = 200;
+
+pub struct TauriGhBackend {
+    handle: AppHandle,
+}
+
+impl TauriGhBackend {
+    pub fn new(handle: AppHandle) -> Arc<Self> {
+        Arc::new(Self { handle })
+    }
+
+    fn db(&self) -> StateDb {
+        self.handle.state::<AppState>().storage.clone()
+    }
+
+    fn list_active_gh_sessions(&self) -> Vec<StoredReviewSession> {
+        self.db()
+            .list_recent_sessions(
+                Some(ReviewSessionKind::GitHubPr),
+                Some(ReviewSessionStatus::Active),
+                SESSION_LIST_LIMIT,
+            )
+            .unwrap_or_default()
+    }
+
+    fn load_session(&self, session_id: &str) -> Option<GitHubPrSession> {
+        load_session_by_id(&self.db(), session_id).ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Stable, positive 53-bit hash of a GraphQL node id. Fits losslessly in JSON
+/// numbers and round-trips through `Number(commentId)` on the client side.
+fn hash_node_id(node_id: &str) -> i64 {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    node_id.hash(&mut h);
+    (h.finish() & 0x001F_FFFF_FFFF_FFFF) as i64
+}
+
+fn split_owner_repo(repo: &str) -> Option<(String, String)> {
+    repo.split_once('/').map(|(o, n)| (o.into(), n.into()))
+}
+
+fn session_to_ref(s: &StoredReviewSession) -> Option<SessionRef> {
+    let repo = s.repo.as_deref()?;
+    let (owner, repo_name) = split_owner_repo(repo)?;
+    Some(SessionRef {
+        id: s.id.clone(),
+        owner,
+        repo: repo_name,
+        number: u64::from(s.pr_number?),
+        title: s.title.clone().unwrap_or_default(),
+        body: s.body.clone().unwrap_or_default(),
+        head_ref: s.head_ref.clone().unwrap_or_default(),
+        head_sha: s.head_sha.clone().unwrap_or_default(),
+        base_ref: s.base_ref.clone().unwrap_or_default(),
+        base_sha: s.base_sha.clone().unwrap_or_default(),
+        author_login: s.author_login.clone().unwrap_or_default(),
+        viewer_login: s.viewer_login.clone().unwrap_or_default(),
+        html_url: s.url.clone().unwrap_or_default(),
+    })
+}
+
+/// Walk every sidecar in a session and yield (sidecar_path, source_path,
+/// relative_path_from_worktree, annotation). The annotation is cloned out so
+/// callers don't keep the sidecar file open.
+fn walk_annotations(
+    session: &GitHubPrSession,
+) -> Vec<(PathBuf, PathBuf, String, Annotation)> {
+    let mut out = Vec::new();
+    let sidecars = list_session_sidecars(session).unwrap_or_default();
+    for (source_path, sidecar_path) in sidecars {
+        let Ok(sidecar) = SidecarFile::load(&sidecar_path) else {
+            continue;
+        };
+        let relative = source_path
+            .strip_prefix(&session.worktree_path)
+            .ok()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|| source_path.to_string_lossy().into_owned());
+        for annotation in sidecar.annotations {
+            out.push((
+                sidecar_path.clone(),
+                source_path.clone(),
+                relative.clone(),
+                annotation,
+            ));
+        }
+    }
+    out
+}
+
+fn anchor_line(a: &Annotation) -> u32 {
+    let Anchor::TextContext { range, .. } = &a.anchor;
+    range.start_line
+}
+
+fn annotation_node_id(a: &Annotation) -> Option<&str> {
+    a.github.as_ref()?.external_comment_id.as_deref()
+}
+
+fn annotation_thread_id(a: &Annotation) -> Option<&str> {
+    a.github.as_ref()?.external_thread_id.as_deref()
+}
+
+/// Stable REST `databaseId` for an annotation. Imported comments hash their
+/// upstream node id; locally-authored drafts (agent replies, future user
+/// drafts) hash their local UUID. Either way the value is stable across calls
+/// so clients can reply to it.
+fn database_id_for(a: &Annotation) -> i64 {
+    match annotation_node_id(a) {
+        Some(node_id) => hash_node_id(node_id),
+        None => hash_node_id(&a.id),
+    }
+}
+
+fn node_id_for(a: &Annotation) -> String {
+    match annotation_node_id(a) {
+        Some(node_id) => node_id.to_string(),
+        None => format!("REDPEN_DRAFT_{}", a.id),
+    }
+}
+
+/// True for annotation kinds that represent a PR review comment / line note.
+/// Filters out labels, questions, and explanations — those aren't reviews.
+fn is_review_kind(kind: &AnnotationKind) -> bool {
+    matches!(kind, AnnotationKind::Comment | AnnotationKind::LineNote)
+}
+
+/// Synthetic thread id for locally-authored review comments that have no
+/// upstream GitHub thread. Format keeps it distinguishable from real
+/// `PRRT_*` ids and stable across reads.
+fn synthetic_thread_id(local_uuid: &str) -> String {
+    format!("REDPEN_THREAD_{}", local_uuid)
+}
+
+/// Where to store a new top-level review comment for `absolute_source_path`
+/// inside the given session. Mirrors `session_sidecar_path` in github_review.rs
+/// but without erroring when the source file is outside the worktree (we just
+/// fall back to the file name).
+fn sidecar_path_for(
+    session: &GitHubPrSession,
+    absolute_source_path: &Path,
+) -> Option<PathBuf> {
+    let session_dir = dirs::home_dir()?
+        .join(".config")
+        .join("redpen")
+        .join("sessions")
+        .join(&session.id)
+        .join("comments");
+    let relative = absolute_source_path
+        .strip_prefix(&session.worktree_path)
+        .ok()?;
+    let file_name = relative.file_name()?.to_string_lossy().into_owned();
+    Some(session_dir.join(relative.with_file_name(format!("{file_name}.json"))))
+}
+
+fn to_review_comment(
+    a: &Annotation,
+    relative_path: &str,
+    pr_url: &str,
+    parent_db_id: Option<i64>,
+) -> ReviewComment {
+    let database_id = database_id_for(a);
+    ReviewComment {
+        database_id,
+        node_id: node_id_for(a),
+        thread_id: annotation_thread_id(a).unwrap_or("").to_string(),
+        path: relative_path.to_string(),
+        line: anchor_line(a),
+        diff_hunk: String::new(),
+        body: a.body.clone(),
+        author: a.author.clone(),
+        created_at: a.created_at.unwrap_or_else(Utc::now),
+        updated_at: a.updated_at.unwrap_or_else(Utc::now),
+        in_reply_to_database_id: parent_db_id,
+        html_url: format!("{}#discussion_r{}", pr_url, database_id),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Trait impl
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl GhBackend for TauriGhBackend {
+    async fn find_session_for_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+    ) -> Option<SessionRef> {
+        let target = format!("{}/{}", owner, repo);
+        self.list_active_gh_sessions()
+            .iter()
+            .find(|s| {
+                s.repo.as_deref() == Some(target.as_str())
+                    && s.head_ref.as_deref() == Some(branch)
+            })
+            .and_then(session_to_ref)
+    }
+
+    async fn find_session_for_pr(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u64,
+    ) -> Option<SessionRef> {
+        let target = format!("{}/{}", owner, repo);
+        self.list_active_gh_sessions()
+            .iter()
+            .find(|s| {
+                s.repo.as_deref() == Some(target.as_str())
+                    && s.pr_number.map(u64::from) == Some(number)
+            })
+            .and_then(session_to_ref)
+    }
+
+    async fn list_active_sessions(&self) -> Vec<SessionRef> {
+        self.list_active_gh_sessions()
+            .iter()
+            .filter_map(session_to_ref)
+            .collect()
+    }
+
+    async fn list_review_comments(&self, session_id: &str) -> Vec<ReviewComment> {
+        let Some(session) = self.load_session(session_id) else {
+            return Vec::new();
+        };
+        let entries = walk_annotations(&session);
+
+        // Pass 1: every review-kind annotation (imported or draft) gets a
+        // stable database_id, indexed by local UUID for in_reply_to mapping.
+        let mut local_to_db: HashMap<String, i64> = HashMap::new();
+        for (_, _, _, a) in &entries {
+            if is_review_kind(&a.kind) {
+                local_to_db.insert(a.id.clone(), database_id_for(a));
+            }
+        }
+
+        // Pass 2: produce ReviewComments. Includes drafts (agent replies,
+        // PendingPublish) so subsequent reads see prior responses and don't
+        // re-address resolved threads.
+        entries
+            .iter()
+            .filter(|(_, _, _, a)| is_review_kind(&a.kind))
+            .map(|(_, _, relative, a)| {
+                let parent_db = a
+                    .reply_to
+                    .as_deref()
+                    .and_then(|local| local_to_db.get(local).copied());
+                to_review_comment(a, relative, &session.url, parent_db)
+            })
+            .collect()
+    }
+
+    async fn list_threads(&self, session_id: &str) -> Vec<ThreadRef> {
+        let Some(session) = self.load_session(session_id) else {
+            return Vec::new();
+        };
+        walk_annotations(&session)
+            .iter()
+            .filter(|(_, _, _, a)| a.reply_to.is_none() && is_review_kind(&a.kind))
+            .map(|(_, _, _, a)| ThreadRef {
+                node_id: annotation_thread_id(a)
+                    .map(String::from)
+                    .unwrap_or_else(|| synthetic_thread_id(&a.id)),
+                is_resolved: a.resolved,
+                root_database_id: database_id_for(a),
+            })
+            .collect()
+    }
+
+    async fn append_review_comment(
+        &self,
+        session_id: &str,
+        agent: &str,
+        path: &str,
+        line: u32,
+        body: &str,
+    ) -> Result<ReviewComment, BackendError> {
+        let session = self
+            .load_session(session_id)
+            .ok_or(BackendError::NotFound)?;
+
+        // Resolve the file path inside the worktree and load (or create) its
+        // sidecar. `path` is relative to the repo root.
+        let absolute = std::path::Path::new(&session.worktree_path).join(path);
+        let sidecar_path = sidecar_path_for(&session, &absolute).ok_or_else(|| {
+            BackendError::Internal(format!("could not derive sidecar path for {}", path))
+        })?;
+        if let Some(parent) = sidecar_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| BackendError::Internal(format!("create sidecar dir: {e}")))?;
+        }
+
+        // Anchor at the requested line. We don't have the file's source hash
+        // available cheaply; use an empty hash + minimal anchor (Redpen will
+        // re-anchor on next load if the source has changed).
+        let anchor = Anchor::TextContext {
+            line_content: String::new(),
+            surrounding_lines: vec![],
+            content_hash: String::new(),
+            range: redpen_core::annotation::Range {
+                start_line: line,
+                start_column: 0,
+                end_line: line,
+                end_column: 0,
+            },
+            last_known_line: line,
+        };
+
+        let mut annotation = Annotation::new(
+            redpen_core::annotation::AnnotationKind::Comment,
+            body.to_string(),
+            vec![],
+            agent.to_string(),
+            anchor,
+        );
+        // Bot-seeded comments are local-only review content. Synthesize a
+        // thread id so list_threads/set_thread_resolved can address them.
+        annotation.github = Some(GitHubAnnotationMetadata {
+            sync_state: Some(GitHubSyncState::LocalOnly),
+            external_comment_id: None,
+            external_thread_id: Some(synthetic_thread_id(&annotation.id)),
+            publishable_reason: None,
+        });
+
+        let mut sidecar = if sidecar_path.exists() {
+            SidecarFile::load(&sidecar_path)
+                .map_err(|e| BackendError::Internal(format!("load sidecar: {e}")))?
+        } else {
+            // No content_hash available without reading the file — use empty.
+            SidecarFile::new(String::new())
+        };
+        sidecar.annotations.push(annotation.clone());
+        sidecar
+            .save(&sidecar_path)
+            .map_err(|e| BackendError::Internal(format!("save sidecar: {e}")))?;
+
+        let database_id = database_id_for(&annotation);
+        Ok(ReviewComment {
+            database_id,
+            node_id: node_id_for(&annotation),
+            thread_id: synthetic_thread_id(&annotation.id),
+            path: path.to_string(),
+            line,
+            diff_hunk: String::new(),
+            body: annotation.body.clone(),
+            author: annotation.author.clone(),
+            created_at: annotation.created_at.unwrap_or_else(Utc::now),
+            updated_at: annotation.updated_at.unwrap_or_else(Utc::now),
+            in_reply_to_database_id: None,
+            html_url: format!("{}#discussion_r{}", session.url, database_id),
+        })
+    }
+
+    async fn append_reply(
+        &self,
+        session_id: &str,
+        parent_database_id: i64,
+        agent: &str,
+        body: &str,
+    ) -> Result<ReviewComment, BackendError> {
+        let session = self
+            .load_session(session_id)
+            .ok_or(BackendError::NotFound)?;
+
+        // Find the parent annotation by its stable database_id (works for
+        // both imported comments and prior agent drafts).
+        let entries = walk_annotations(&session);
+        let parent = entries
+            .iter()
+            .find(|(_, _, _, a)| {
+                is_review_kind(&a.kind) && database_id_for(a) == parent_database_id
+            })
+            .ok_or(BackendError::NotFound)?
+            .clone();
+        let (parent_sidecar, _parent_source, parent_relative, parent_annotation) = parent;
+
+        // Build the reply annotation, reusing the parent's anchor so it
+        // anchors to the same line in the same file.
+        let mut reply = Annotation::new_reply(
+            body.to_string(),
+            agent.to_string(),
+            parent_annotation.id.clone(),
+            parent_annotation.anchor.clone(),
+        );
+        reply.github = Some(GitHubAnnotationMetadata {
+            sync_state: Some(GitHubSyncState::PendingPublish),
+            external_comment_id: None,
+            external_thread_id: parent_annotation
+                .github
+                .as_ref()
+                .and_then(|m| m.external_thread_id.clone()),
+            publishable_reason: None,
+        });
+
+        // Append + save the sidecar that holds the parent.
+        let mut sidecar = SidecarFile::load(&parent_sidecar)
+            .map_err(|e| BackendError::Internal(format!("load sidecar: {e}")))?;
+        sidecar.annotations.push(reply.clone());
+        sidecar
+            .save(&parent_sidecar)
+            .map_err(|e| BackendError::Internal(format!("save sidecar: {e}")))?;
+
+        let database_id = database_id_for(&reply);
+        Ok(ReviewComment {
+            database_id,
+            node_id: node_id_for(&reply),
+            thread_id: parent_annotation
+                .github
+                .as_ref()
+                .and_then(|m| m.external_thread_id.clone())
+                .unwrap_or_default(),
+            path: parent_relative,
+            line: anchor_line(&reply),
+            diff_hunk: String::new(),
+            body: reply.body.clone(),
+            author: reply.author.clone(),
+            created_at: reply.created_at.unwrap_or_else(Utc::now),
+            updated_at: reply.updated_at.unwrap_or_else(Utc::now),
+            in_reply_to_database_id: Some(parent_database_id),
+            html_url: format!("{}#discussion_r{}", session.url, database_id),
+        })
+    }
+
+    async fn set_thread_resolved(
+        &self,
+        _session_id: &str,
+        thread_node_id: &str,
+        resolved: bool,
+    ) -> Result<ThreadRef, BackendError> {
+        // GraphQL mutation only carries the threadId — scan all active GH
+        // sessions to find the owning sidecar.
+        for stored in self.list_active_gh_sessions() {
+            let Some(session) = self.load_session(&stored.id) else {
+                continue;
+            };
+            for (sidecar_path, _, _, _) in walk_annotations(&session) {
+                let mut sidecar = match SidecarFile::load(&sidecar_path) {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+                let mut hit = None;
+                for annotation in sidecar.annotations.iter_mut() {
+                    if annotation.reply_to.is_some() {
+                        continue; // only roots can resolve a thread
+                    }
+                    let matches_external =
+                        annotation_thread_id(annotation) == Some(thread_node_id);
+                    let matches_synthetic =
+                        synthetic_thread_id(&annotation.id) == thread_node_id;
+                    if matches_external || matches_synthetic {
+                        annotation.resolved = resolved;
+                        annotation.updated_at = Some(Utc::now());
+                        hit = Some(ThreadRef {
+                            node_id: thread_node_id.to_string(),
+                            is_resolved: resolved,
+                            root_database_id: database_id_for(annotation),
+                        });
+                        break;
+                    }
+                }
+                if let Some(thread_ref) = hit {
+                    sidecar
+                        .save(&sidecar_path)
+                        .map_err(|e| BackendError::Internal(format!("save sidecar: {e}")))?;
+                    let _ = Path::new(&sidecar_path); // silence unused (compiler fine, but keeps intent)
+                    return Ok(thread_ref);
+                }
+            }
+        }
+        Err(BackendError::NotFound)
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod bridge;
 mod commands;
 mod event_bus;
+mod gh_fake_backend;
 mod notification;
 mod settings;
 mod state;
@@ -383,11 +384,16 @@ pub fn run() {
                 }; // semicolon ensures MutexGuard drops before state
             }
 
-            // Start optional local HTTP server for CLI/agent communication
+            // Start optional local HTTP server for CLI/agent communication.
+            // Mounts both /rpc/* (Redpen RPC) and the GitHub-API-compatible
+            // routes that back the agent-reviews compatibility shim.
             let bridge = bridge::TauriBridge::new(app.handle().clone());
+            let gh_backend = gh_fake_backend::TauriGhBackend::new(app.handle().clone());
             let review_sessions = app.state::<AppState>().review_sessions.clone();
             tauri::async_runtime::spawn(async move {
-                if let Err(e) = redpen_server::start_server(bridge, review_sessions).await {
+                if let Err(e) =
+                    redpen_server::start_server(bridge, review_sessions, Some(gh_backend)).await
+                {
                     eprintln!("Red Pen server failed to start: {}", e);
                 }
             });


### PR DESCRIPTION
## Summary

Adds a localhost HTTP server (`redpen-gh-fake`) that speaks enough of the GitHub REST + GraphQL API surface that any GitHub-aware tool (`agent-reviews`, `@octokit/rest`, `python-requests`, `gh api`) can run against an active Redpen review session instead of api.github.com. Writes land as `PendingPublish` annotations in session sidecars so the human reviewer edits / discards / publishes via the existing "Submit review" flow.

Also adds the CLI surface that makes this usable end-to-end (`redpen url`, `sessions`, `run`, `review`, `watch`, `install-skills`) and a Claude Code skill (`resolve-redpen-reviews`) that drives the full fix-commit-reply-watch loop against a Redpen session.

## What's in the diff

- **`crates/redpen-gh-fake/`** — new crate, pluggable `GhBackend` trait + axum router, mounted at `/` and `/api/v3/...`. Includes `/redpen/meta` self-describing endpoint for skill discovery.
- **`src-tauri/src/gh_fake_backend.rs`** — Tauri-side adapter implementing `GhBackend` over the real Storage + sidecar layer. Synthetic 53-bit `database_id` (hash of GraphQL node id) keeps REST ids stable without schema changes.
- **`crates/redpen-server/`** — `start_server` now takes `Option<Arc<dyn GhBackend>>` and merges the gh-fake router onto the same listener as `/rpc/*`.
- **`crates/redpen-cli/`** — six new subcommands: `url`, `sessions`, `run`, `review`, `watch`, `install-skills`. Auto-injects `GITHUB_API_URL`/`GH_REPO`/`REDPEN_PR` when exactly one session is active. `--remote` flag opts out for talking to real GitHub via the same wrapper. `redpen watch` is a native poll loop (no Node dependency); output markers match `agent-reviews --watch` so the same skill drives either watcher.
- **`crates/redpen-cli/skills/resolve-redpen-reviews/SKILL.md`** — embedded into the binary, installed by `redpen install-skills`. Mirrors agent-reviews's `resolve-reviews` structure (Phase 1 fix → commit → reply, Phase 2 watch loop) but uses `redpen review` / `redpen watch` and front-loads the drafts-only semantics.

## Test plan

- [x] `cargo test --workspace` — 140 tests passing
- [x] `redpen-gh-fake` integration tests cover all 8 endpoints + the meta endpoint, with both native `reqwest` and real external clients (Octokit via dynamic ESM import, Python urllib, gh CLI via TLS shim)
- [x] End-to-end loop verified: bot seeds findings via `POST /pulls/{n}/comments`, agent reads via `redpen review --pr N --unanswered`, posts replies via `--reply ... --resolve`, watch loop exits cleanly on idle and on new-comment detection
- [x] Smoke tested with a Haiku subagent following the installed skill end-to-end against a seeded server

## Known follow-ups

These don't block this PR but are tracked for a follow-up:

- **Schema split** for REST `databaseId` vs GraphQL `node_id` (currently we synthesize a stable hash; this works for local round-trips but the existing `submit_github_pr_review` path also has a pre-existing bug where it sends GraphQL node ids to a REST endpoint — needs the same fix).
- **Pending-resolution flag** + GraphQL `resolveReviewThread` in `submit_github_pr_review`, so an agent's `set_thread_resolved` actually propagates to GitHub when the human submits.
- **`agent-reviews` upstream PR** (pbakaus/agent-reviews#7) adding `GITHUB_API_URL` support is open but not yet merged. Until then, install via `npm i -g github:sam-phinizy/agent-reviews#add-github-api-url-env`. Once merged, point `redpen review` at plain `agent-reviews`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `watch` command to monitor PR comments with configurable polling intervals and idle timeouts
  * Added `sessions` command to list active GitHub review sessions
  * Added `url` command to display local server address
  * Added `install-skills` command to manage Claude Code skills installation
  * Added `resolve-redpen-reviews` skill for automating review workflows
  * Added local GitHub API-compatible server for development and testing with GraphQL support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->