### PR TITLE
ci: sign and notarize macOS release builds with Developer ID

### DIFF
--- a/.env.signing.example
+++ b/.env.signing.example
@@ -1,0 +1,16 @@
+# Apple Developer ID code signing identity (public string — find via
+# `security find-identity -v -p codesigning`). Format:
+#   "Developer ID Application: <Name> (<TeamID>)"
+APPLE_SIGNING_IDENTITY=Developer ID Application: Your Name (J35P7AJDN7)
+
+# Apple Developer ID certificate, imported into a temp keychain by
+# scripts/ci-setup-macos-keychain.sh on CI runners. Local dev uses the
+# developer's login keychain, so these are only needed for `sync-gh-secrets`.
+# Note: use literal spaces in op:// refs, not %20.
+APPLE_CERTIFICATE=op://Development/Tauri Signing/apple_certificate_base64
+APPLE_CERTIFICATE_PASSWORD=op://Development/Tauri Signing/apple_certificate_password
+
+# Notarization via Apple ID + app-specific password.
+APPLE_ID=op://Development/Tauri Signing/apple_id
+APPLE_PASSWORD=op://Development/Tauri Signing/app_specific_password
+APPLE_TEAM_ID=op://Development/Tauri Signing/team_id

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
         include:
           - runner: macos-latest
             target: aarch64-apple-darwin
-          - runner: macos-13
-            target: x86_64-apple-darwin
     steps:
       - uses: actions/checkout@v4
 
@@ -41,21 +39,32 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      - name: Install Task
+        run: brew install go-task
+
       - name: Install frontend dependencies
         run: bun install
 
-      - name: Build Tauri app
-        run: bun run tauri build --target ${{ matrix.target }}
+      - name: Import Developer ID cert
         env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: ./scripts/ci-setup-macos-keychain.sh
+
+      - name: Build, sign, notarize, staple
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: task build:signed
 
       - name: Upload DMG
         uses: actions/upload-artifact@v4
         with:
           name: desktop-${{ matrix.target }}
           path: |
-            target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            target/release/bundle/dmg/*.dmg
           if-no-files-found: error
 
   build-cli:
@@ -68,8 +77,6 @@ jobs:
         include:
           - runner: macos-latest
             target: aarch64-apple-darwin
-          - runner: macos-13
-            target: x86_64-apple-darwin
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 .claude/settings.local.json
 .superpowers/
 .env*
+!.env.signing.example
 
 # Signing certificates and keys
 *.crt

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,10 +69,13 @@ tasks:
         echo "Installed redpen-cli to $(which redpen)"
 
   sign:
-    desc: "Sign and notarize the already-built app bundle"
-    dotenv: [".env.signing"]
+    desc: "Sign and notarize the already-built app bundle (expects APPLE_* env vars set)"
     cmds:
       - |
+        : "${APPLE_SIGNING_IDENTITY:?must be set}"
+        : "${APPLE_ID:?must be set}"
+        : "${APPLE_PASSWORD:?must be set}"
+        : "${APPLE_TEAM_ID:?must be set}"
         codesign --force --deep --sign "$APPLE_SIGNING_IDENTITY" \
           "target/release/bundle/macos/Red Pen.app"
         echo "Signed Red Pen.app"
@@ -87,12 +90,31 @@ tasks:
         xcrun stapler staple "target/release/bundle/dmg/Red Pen_$(cat src-tauri/tauri.conf.json | python3 -c 'import json,sys;print(json.load(sys.stdin)["version"])')_aarch64.dmg"
         echo "Stapled"
 
+  sign:op:
+    desc: "Run the signing workflow with secrets loaded from 1Password"
+    preconditions:
+      - sh: "command -v op >/dev/null 2>&1"
+        msg: "1Password CLI 'op' is required"
+      - sh: '[ -f ".env.signing" ]'
+        msg: ".env.signing is required (copy from .env.signing.example)"
+    cmds:
+      - op run --env-file=.env.signing -- task sign
+
   build:signed:
-    desc: "Build and sign the app (sources .env.signing)"
-    dotenv: [".env.signing"]
+    desc: "Build and sign the app (expects APPLE_* env vars set)"
     cmds:
       - bun run tauri build
       - task: sign
+
+  build:signed:op:
+    desc: "Build and sign the app with secrets loaded from 1Password"
+    preconditions:
+      - sh: "command -v op >/dev/null 2>&1"
+        msg: "1Password CLI 'op' is required"
+      - sh: '[ -f ".env.signing" ]'
+        msg: ".env.signing is required (copy from .env.signing.example)"
+    cmds:
+      - op run --env-file=.env.signing -- task build:signed
 
   changelog:
     desc: Generate changelog for the latest tag

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -174,8 +174,10 @@ tasks:
         msg: "Working tree must be clean before releasing"
     cmds:
       - |
-        # Get current version from latest tag (strip leading v), default to 0.1.0
-        TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+        # Pick the highest v* tag in the repo, not just one reachable from
+        # HEAD — release PRs are squash-merged, so the tagged commit usually
+        # isn't an ancestor of main.
+        TAG=$(git tag --list 'v*' --sort=-version:refname | head -n1)
         if [ -z "$TAG" ]; then
           CURRENT="0.1.0"
         else
@@ -203,8 +205,8 @@ tasks:
           sed -i '' "s/^version = \".*\"/version = \"${NEW}\"/" "$f"
         done
 
-        # Generate changelog
-        git cliff --latest --strip header -o CHANGELOG.md
+        # Regenerate the full changelog so older sections aren't dropped.
+        git cliff --tag "v${NEW}" -o CHANGELOG.md
 
         # Commit, tag, push
         git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml crates/redpen-cli/Cargo.toml crates/redpen-core/Cargo.toml CHANGELOG.md

--- a/scripts/ci-setup-macos-keychain.sh
+++ b/scripts/ci-setup-macos-keychain.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Create a temporary keychain on a CI runner and import the Developer ID
+# Application certificate from $APPLE_CERTIFICATE (base64-encoded .p12) so
+# `codesign` can run unattended. Only meant for CI; local dev uses the
+# developer's login keychain.
+set -euo pipefail
+
+: "${APPLE_CERTIFICATE:?base64-encoded .p12 required}"
+: "${APPLE_CERTIFICATE_PASSWORD:?.p12 password required}"
+: "${RUNNER_TEMP:?RUNNER_TEMP must be set (GitHub Actions runner var)}"
+
+KEYCHAIN_NAME="redpen-build.keychain"
+KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+CERT_PATH="${RUNNER_TEMP}/cert.p12"
+
+cleanup() { rm -f "${CERT_PATH}"; }
+trap cleanup EXIT
+
+printf '%s' "${APPLE_CERTIFICATE}" | base64 --decode > "${CERT_PATH}"
+
+security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+security set-keychain-settings -lut 21600 "${KEYCHAIN_NAME}"
+security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+
+# Prepend the build keychain to the user search list so codesign finds the identity.
+EXISTING_KEYCHAINS=$(security list-keychains -d user | sed -E 's/^[[:space:]]*"?//; s/"?$//')
+# shellcheck disable=SC2086
+security list-keychains -d user -s "${KEYCHAIN_NAME}" ${EXISTING_KEYCHAINS}
+
+security import "${CERT_PATH}" \
+  -k "${KEYCHAIN_NAME}" \
+  -P "${APPLE_CERTIFICATE_PASSWORD}" \
+  -T /usr/bin/codesign \
+  -T /usr/bin/security \
+  -T /usr/bin/productbuild
+
+security set-key-partition-list \
+  -S apple-tool:,apple: \
+  -s -k "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}" >/dev/null
+
+echo "Imported signing identities:"
+security find-identity -v -p codesigning "${KEYCHAIN_NAME}"

--- a/scripts/sync-gh-secrets.sh
+++ b/scripts/sync-gh-secrets.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# One-shot bootstrap: read .env.signing via `op run`, then push each value
+# into GitHub Actions secrets via `gh secret set`. Idempotent — rerun after
+# rotating anything in 1Password.
+set -euo pipefail
+
+VARS=(
+  APPLE_SIGNING_IDENTITY
+  APPLE_CERTIFICATE
+  APPLE_CERTIFICATE_PASSWORD
+  APPLE_ID
+  APPLE_PASSWORD
+  APPLE_TEAM_ID
+)
+
+command -v op >/dev/null || { echo "op CLI required" >&2; exit 1; }
+command -v gh >/dev/null || { echo "gh CLI required" >&2; exit 1; }
+[ -f .env.signing ] || { echo ".env.signing not found in $(pwd)" >&2; exit 1; }
+
+missing=()
+for v in "${VARS[@]}"; do
+  if ! grep -qE "^${v}=" .env.signing; then
+    missing+=("$v")
+  fi
+done
+if (( ${#missing[@]} > 0 )); then
+  echo "Missing from .env.signing (uncomment or add these lines):" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+# op run expands op:// refs into real env values for the child process.
+# --no-masking keeps stderr diagnostics readable on failure; the actual
+# secret values are still piped directly to `gh secret set --body -`.
+op run --env-file=.env.signing --no-masking -- bash -c '
+  set -euo pipefail
+  for v in '"${VARS[*]}"'; do
+    val="${!v-}"
+    if [ -z "$val" ]; then
+      echo "Skipping ${v} (empty after op resolution)" >&2
+      continue
+    fi
+    printf "%s" "$val" | gh secret set "$v"
+    echo "Set ${v}"
+  done
+'


### PR DESCRIPTION
## Summary
- Imports the Apple Developer ID cert into a temp keychain on the CI runner via `scripts/ci-setup-macos-keychain.sh`, then runs `task build:signed` so the release workflow produces a codesigned, notarized, stapled DMG instead of a raw bundle.
- Drops the `x86_64-apple-darwin` matrix entry from both `build-desktop` and `build-cli` (Apple Silicon only going forward).
- Refactors `task sign` / `task build:signed` to take `APPLE_*` via environment variables (so CI can pass them as secrets), with `:op` variants that load values from 1Password for local use.
- Adds `.env.signing.example` (template pointing at `op://Development/Tauri Signing/...`) and `scripts/sync-gh-secrets.sh` (one-shot bootstrap that pushes those secrets into GitHub Actions).

## Test plan
- [ ] Run `./scripts/sync-gh-secrets.sh` locally to populate the repo's Actions secrets (`APPLE_SIGNING_IDENTITY`, `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`).
- [ ] Push a `v*` tag and confirm the release workflow's `build-desktop` job: imports the cert, builds, signs, notarizes, staples, and uploads a `.dmg` artifact.
- [ ] Spot-check the artifact: `codesign -dv --verbose=4 "Red Pen.app"` and `spctl -a -t exec -vv "Red Pen.app"` should both report Developer ID + accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS desktop releases are now Developer ID signed and notarized for smoother installation and fewer security prompts.
  * Intel (x86_64) macOS build target removed—releases focus on modern macOS architectures.

* **Chores**
  * Release tooling updated to support secure signing/notarization workflows, including an example signing env and CI helpers for managing signing credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->